### PR TITLE
feat(gitbrowse): open file in `gitbrowse` in corresponding remote

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -71,11 +71,20 @@ function M.open(opts)
       local url = M.get_url(remote, opts)
       if url:find("github") and branch and branch ~= "master" and branch ~= "main" then
         url = ("%s/tree/%s"):format(url, branch)
+      elseif branch == "main" then
+        url = ("%s/tree/main"):format(url)
+      elseif branch == "master" then
+        url = ("%s/tree/master"):format(url)
       end
       if url then
         table.insert(remotes, {
           name = name,
           url = url,
+          file = vim
+            .system({ "realpath", "--relative-to=$(git rev-parse --show-toplevel)", vim.fn.expand("%:p") })
+            :wait().stdout
+            :gsub("\n", "")
+            :gsub("%.%.", ""),
         })
       end
     end
@@ -84,7 +93,7 @@ function M.open(opts)
   local function open(remote)
     if remote then
       Snacks.notify(("Opening [%s](%s)"):format(remote.name, remote.url), { title = "Git Browse" })
-      opts.open(remote.url)
+      opts.open(remote.url .. remote.file)
     end
   end
 


### PR DESCRIPTION
## Description
`gitbrowse` now opens the file in corresponding remote instead of just the remote.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #10.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

