### PR TITLE
feat(gitbrowse): open file in `gitbrowse` in corresponding remote

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -70,12 +70,17 @@ function M.open(opts)
     if name and remote then
       local url = M.get_url(remote, opts)
       if url:find("github") and branch and branch ~= "master" and branch ~= "main" then
-        url = ("%s/tree/%s"):format(url, branch)
+        url = ("%s/tree/%s/"):format(url, branch)
+      elseif branch == "main" then
+        url = ("%s/tree/main/"):format(url)
+      elseif branch == "master" then
+        url = ("%s/tree/master/"):format(url)
       end
       if url then
         table.insert(remotes, {
           name = name,
           url = url,
+          file = vim.system({ "git", "ls-files", "--full-name", vim.fn.expand("%") }):wait().stdout:gsub("\n", ""),
         })
       end
     end
@@ -84,7 +89,7 @@ function M.open(opts)
   local function open(remote)
     if remote then
       Snacks.notify(("Opening [%s](%s)"):format(remote.name, remote.url), { title = "Git Browse" })
-      opts.open(remote.url)
+      opts.open(remote.url .. remote.file)
     end
   end
 


### PR DESCRIPTION
## Description
`gitbrowse` opens the file in Github instead of just the repo. I closed #15 because when you were in a nested directory inside the local git repo it didn't open the file correctly. This rectifies that behavior. I hope I didn't miss anything else.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #10.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

