### PR TITLE
fix(win): set border to none for backdrop windows

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -429,6 +429,7 @@ function M:drop()
       height = 0,
       width = 0,
       style = "minimal",
+      border = "none",
       focusable = false,
       zindex = self.opts.zindex - 1,
       wo = {


### PR DESCRIPTION
## Description
Previously, backdrop windows were being created with the default border options set in `opts`. I can't imagine this is ever desirable (see screenshots), so always set the backdrop window border to none.

## Related Issue(s)
N/A

## Screenshots
### Before:
![image](https://github.com/user-attachments/assets/1ff0d810-ac6a-4309-b198-125f2a68331c)

### After:
![image](https://github.com/user-attachments/assets/2f1b348e-4e55-4631-934f-67896c0e2488)