### PR TITLE
feat(words): `jump` optionally shows notification with reference count

### DIFF
--- a/doc/snacks-words.txt
+++ b/doc/snacks-words.txt
@@ -18,6 +18,8 @@ Auto-show LSP references and quickly navigate between them
     {
       enabled = true, -- enable/disable the plugin
       debounce = 200, -- time in ms to wait before updating
+      notify_jump = true, -- show a notification when jumping
+      notify_end = true, -- show a notification when reaching the end
     }
 <
 

--- a/docs/words.md
+++ b/docs/words.md
@@ -11,6 +11,8 @@ Auto-show LSP references and quickly navigate between them
 {
   enabled = true, -- enable/disable the plugin
   debounce = 200, -- time in ms to wait before updating
+  notify_jump = true, -- show a notification when jumping
+  notify_end = true, -- show a notification when reaching the end
 }
 ```
 
@@ -28,6 +30,5 @@ Snacks.words.is_enabled(buf)
 ```lua
 ---@param count number
 ---@param cycle? boolean
----@param notify? boolean
-Snacks.words.jump(count, cycle, notify)
+Snacks.words.jump(count, cycle)
 ```

--- a/docs/words.md
+++ b/docs/words.md
@@ -28,5 +28,6 @@ Snacks.words.is_enabled(buf)
 ```lua
 ---@param count number
 ---@param cycle? boolean
-Snacks.words.jump(count, cycle)
+---@param notify? boolean
+Snacks.words.jump(count, cycle, notify)
 ```

--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -9,6 +9,8 @@ local M = {}
 local defaults = {
   enabled = true, -- enable/disable the plugin
   debounce = 200, -- time in ms to wait before updating
+  notify_jump = true, -- show a notification when jumping
+  notify_end = true, -- show a notification when reaching the end
 }
 
 local config = Snacks.config.get("words", defaults)
@@ -77,8 +79,7 @@ end
 
 ---@param count number
 ---@param cycle? boolean
----@param notify? boolean
-function M.jump(count, cycle, notify)
+function M.jump(count, cycle)
   local words, idx = M.get()
   if not idx then
     return
@@ -90,9 +91,11 @@ function M.jump(count, cycle, notify)
   local target = words[idx]
   if target then
     vim.api.nvim_win_set_cursor(0, target.from)
-    if notify then
-      Snacks.notify.info(("Reference %d/%d"):format(idx, #words), { id = "snacks.words.jump" })
+    if config.notify_jump then
+      Snacks.notify.info(("Reference %d/%d"):format(idx, #words), { id = "snacks.words.jump", title = "Words" })
     end
+  elseif config.notify_end then
+    Snacks.notify.warn("No more references", { id = "snacks.words.jump", title = "Words" })
   end
 end
 

--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -77,7 +77,8 @@ end
 
 ---@param count number
 ---@param cycle? boolean
-function M.jump(count, cycle)
+---@param notify? boolean
+function M.jump(count, cycle, notify)
   local words, idx = M.get()
   if not idx then
     return
@@ -89,6 +90,9 @@ function M.jump(count, cycle)
   local target = words[idx]
   if target then
     vim.api.nvim_win_set_cursor(0, target.from)
+    if notify then
+      Snacks.notify.info(("Reference %d/%d"):format(idx, #words), { id = "snacks.words.jump" })
+    end
   end
 end
 

--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -92,7 +92,7 @@ function M.jump(count, cycle)
   if target then
     vim.api.nvim_win_set_cursor(0, target.from)
     if config.notify_jump then
-      Snacks.notify.info(("Reference %d/%d"):format(idx, #words), { id = "snacks.words.jump", title = "Words" })
+      Snacks.notify.info(("Reference [%d/%d]"):format(idx, #words), { id = "snacks.words.jump", title = "Words" })
     end
   elseif config.notify_end then
     Snacks.notify.warn("No more references", { id = "snacks.words.jump", title = "Words" })


### PR DESCRIPTION
## Description

Add an opt-in option to show a notification for `Snacks.words.jump`, that displays the number and index of the current reference. The notification uses `Snacks.notify.info` to be consistent with the rest of the repo.

## Screenshots

![Pasted image 2024-11-07 at 16 39 46](https://github.com/user-attachments/assets/35930d62-335a-44b4-be9d-2799c129d324)
