### PR TITLE
docs(rename): add nvim-tree example

### DIFF
--- a/docs/rename.md
+++ b/docs/rename.md
@@ -35,6 +35,24 @@ vim.api.nvim_create_autocmd("User", {
 }
 ```
 
+## [nvim-tree](https://github.com/nvim-tree/nvim-tree.lua)
+
+```lua
+local prev = { new_name = "", old_name = "" } -- Prevents duplicate events
+vim.api.nvim_create_autocmd("User", {
+  pattern = "NvimTreeSetup",
+  callback = function()
+    local events = require("nvim-tree.api").events
+    events.subscribe(events.Event.NodeRenamed, function(data)
+      if prev.new_name ~= data.new_name or prev.old_name ~= data.old_name then
+        data = data
+        Snacks.rename.on_rename_file(data.old_name, data.new_name)
+      end
+    end)
+  end,
+})
+```
+
 <!-- docgen -->
 
 ## 📦 Module


### PR DESCRIPTION
## Description

Adds an example to `rename.md` for nvim-tree. 

I spent way too long obsessing over the way the code looked to make it feel like the other examples.

## Related Issue(s)

N/A

## Screenshots

![2024-11-07-201109_hyprshot](https://github.com/user-attachments/assets/fb3b141d-c8d8-4951-8f97-3242cf7ddb30)