### PR TITLE
fix(terminal): `gf` properly opens file

### DIFF
--- a/lua/snacks/terminal.lua
+++ b/lua/snacks/terminal.lua
@@ -27,12 +27,14 @@ Snacks.config.style("terminal", {
   wo = {},
   keys = {
     gf = function(self)
-      local f = vim.fn.findfile(vim.fn.expand("<cfile>"))
+      local f = vim.fn.findfile(vim.fn.expand("<cfile>"), "**")
       if f == "" then
         Snacks.notify.warn("No file under cursor")
       else
-        self:close()
-        vim.cmd("e " .. f)
+        self:hide()
+        vim.schedule(function()
+          vim.cmd("e " .. f)
+        end)
       end
     end,
     term_normal = {


### PR DESCRIPTION
## Description
1. Currently `gf` only search in current working directory. Use `**` in `findfile()` to do a recursive search. Otherwise, `gf` can't open a file down a nested directory.
2. `vim.schedule` the command `vim.cmd("e ", f)`, because otherwise it opens the file but goes to the buffer that was already opened. Not sure why this happens, but if we schedule it correctly goes to the opened buffer by `gf`.
3. Also changed `self:close()` to `self:toggle()`, so as not to reset the state of the terminal unless a user specifically exits the terminal. This is rather personal and also based on a [LazyVim Discussion](https://github.com/LazyVim/LazyVim/discussions/4741), but I can understand if it's not wanted in the scope of `snacks.nvim` and probably users could change the behavior of the `gf` key in their personal configuration.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
[A LazyVim discussion](https://github.com/LazyVim/LazyVim/discussions/4741)
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

