### PR TITLE
docs(example): fix rename file keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ See the example below for how to configure `snacks.nvim`.
     { "<leader>gB", function() Snacks.gitbrowse() end, desc = "Git Browse" },
     { "<leader>gf", function() Snacks.lazygit.log_file() end, desc = "Lazygit Current File History" },
     { "<leader>gl", function() Snacks.lazygit.log() end, desc = "Lazygit Log (cwd)" },
-    { "<leader>cR", function() Snacks.rename() end, desc = "Rename File" },
+    { "<leader>cR", function() Snacks.rename.rename_file() end, desc = "Rename File" },
     { "<c-/>",      function() Snacks.terminal() end, desc = "Toggle Terminal" },
     { "<c-_>",      function() Snacks.terminal() end, desc = "which_key_ignore" },
     { "]]",         function() Snacks.words.jump(vim.v.count1) end, desc = "Next Reference" },


### PR DESCRIPTION
## Description

Fixes "Rename File" keymap in Usage section of README.

