### PR TITLE
fix(win): take border into account for window position

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -499,6 +499,11 @@ function M:win_opts()
   end
   opts.row = opts.row or math.floor((parent.height - opts.height) / 2)
   opts.col = opts.col or math.floor((parent.width - opts.width) / 2)
+
+  if self:has_border() then
+    opts.row = opts.row - 1
+    opts.col = opts.col - 1
+  end
   return opts
 end
 

--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -497,13 +497,10 @@ function M:win_opts()
   if opts.relative == "cursor" then
     return opts
   end
-  opts.row = opts.row or math.floor((parent.height - opts.height) / 2)
-  opts.col = opts.col or math.floor((parent.width - opts.width) / 2)
+  local border_offset = self:has_border() and 2 or 0
+  opts.row = opts.row or math.floor((parent.height - opts.height - border_offset) / 2)
+  opts.col = opts.col or math.floor((parent.width - opts.width - border_offset) / 2)
 
-  if self:has_border() then
-    opts.row = opts.row - 1
-    opts.col = opts.col - 1
-  end
   return opts
 end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
The window position is not correctly centered when position is set to `float` and border isn't `none`. I found [a similar issue](https://github.com/folke/lazy.nvim/issues/812) in [lazy.nvim](https://github.com/folke/lazy.nvim) along with [your fix](https://github.com/folke/lazy.nvim/commit/451f217e9b2d71f08bdae0ce5ac7e8e8a6503f48) there, so I have applied the same fix here. Thank you for your work!

## Related Issue(s)
https://github.com/folke/lazy.nvim/issues/812

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

### Before
<img width="2240" alt="image" src="https://github.com/user-attachments/assets/6e5eeb7b-7993-4ab5-a40e-c77021a5ccb0">

### After
<img width="2240" alt="image" src="https://github.com/user-attachments/assets/66ad76ab-8ca2-446f-afce-b18599313319">



