### PR TITLE
fix(notifier): disable `colorcolumn` by default

### DIFF
--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -77,6 +77,7 @@ Snacks.config.style("notification", {
     winblend = 5,
     wrap = false,
     conceallevel = 2,
+    colorcolumn = "",
   },
   bo = { filetype = "snacks_notif" },
 })


### PR DESCRIPTION
## Description
`colorcolumn` should be disabled by default, since in most cases, the user will not want to have them displayed in a notification.

## Screenshots
before:
![Pasted image 2024-11-12 at 19 59 40](https://github.com/user-attachments/assets/c866b87a-6cae-4cb1-9a0c-a769acb3e99a)

after:
![Pasted image 2024-11-12 at 20 02 06](https://github.com/user-attachments/assets/55dc0ea7-34f1-47c4-aaf7-f55175422506)



