### PR TITLE
feat(config)!: plugins are no longer enabled by default. Pass any options, or set enabled = true

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Install the plugin with your package manager:
 > Setup creates some autocmds and does not load any plugins.
 > Check the [code](https://github.com/folke/snacks.nvim/blob/main/lua/snacks/init.lua) to see what it does.
 
-> [!tip]
-> If you don't need these plugins, you can disable them, or skip `setup` altogether.
+> [!caution]
+> You need to explicitely pass options for a plugin or set `enabled = true` to enable it.
+
 > ![tip]
 > It' a good idea to run `:checkhealth snacks` to see if everything is set up correctly.
 
@@ -55,6 +56,11 @@ Install the plugin with your package manager:
     -- your configuration comes here
     -- or leave it empty to use the default settings
     -- refer to the configuration section below
+    bigfile = { enabled = true },
+    notifier = { enabled = true },
+    quickfile = { enabled = true },
+    statuscolumn = { enabled = true },
+    words = { enabled = true },
   },
 }
 ```
@@ -77,18 +83,18 @@ Please refer to the readme of each plugin for their specific configuration.
 ---@field notifier? snacks.notifier.Config | { enabled: boolean }
 ---@field quickfile? { enabled: boolean }
 ---@field statuscolumn? snacks.statuscolumn.Config  | { enabled: boolean }
+---@field styles? table<string, snacks.win.Config>
 ---@field terminal? snacks.terminal.Config
 ---@field toggle? snacks.toggle.Config
----@field styles? table<string, snacks.win.Config>
 ---@field win? snacks.win.Config
 ---@field words? snacks.words.Config
 {
   styles = {},
-  bigfile = { enabled = true },
-  notifier = { enabled = true },
-  quickfile = { enabled = true },
-  statuscolumn = { enabled = true },
-  words = { enabled = true },
+  bigfile = { enabled = false },
+  notifier = { enabled = false },
+  quickfile = { enabled = false },
+  statuscolumn = { enabled = false },
+  words = { enabled = false },
 }
 ```
 
@@ -193,38 +199,38 @@ See the example below for how to configure `snacks.nvim`.
 
 <!-- hl_start -->
 
-| Highlight Group                        | Default Group                    | Description                                        |
-| -------------------------------------- | -------------------------------- | -------------------------------------------------- |
-| **SnacksNormal**                       | _NormalFloat_                        | Normal for the float window |
-| **SnacksWinBar**                   | _Title_             | Title of the window                                       |
-| **SnacksBackdrop**         | _none_               | Backdrop                                                   |
-| **SnacksNormalNC**            | _NormalFloat_               | Normal for non-current windows                                                   |
-| **SnacksWinBarNC**             | _SnacksWinBar_               | Title for non-current windows                                                   |
-| **SnacksNotifierInfo**               | _none_               | Notification window for Info                                                   |
-| **SnacksNotifierWarn**          | _none_               | Notification window for Warn                                                   |
-| **SnacksNotifierDebug**              | _none_               | Notification window for Debug                                                 |
-| **SnacksNotifierError**                | _none_               | Notification window for Error                                                   |
-| **SnacksNotifierTrace**             | _none_             | Notification window for Trace                  |
-| **SnacksNotifierIconInfo**                  | _none_                         | Icon for Info notification                       |
-| **SnacksNotifierIconWarn**            | _none_             | Icon for Warn notification                               |
-| **SnacksNotifierIconDebug**  | _none_        | Icon for Debug notification                                                   |
-| **SnacksNotifierIconError**     | _none_        | Icon for Error notification                                                   |
-| **SnacksNotifierIconTrace**      | _none_        | Icon for Trace notification                                                   |
-| **SnacksNotifierTitleInfo**        | _none_        | Title for Info notification                                                   |
-| **SnacksNotifierTitleWarn**   | _none_        | Title for Warn notification                                                   |
-| **SnacksNotifierTitleDebug**       | _none_        | Title for Debug notification                                                   |
-| **SnacksNotifierTitleError**         | _none_        | Title for Error notification                                                   |
-| **SnacksNotifierTitleTrace**      | _none_             | Title for Trace notification                    |
-| **SnacksNotifierBorderInfo**             | _none_             | Border for Info notification                               |
-| **SnacksNotifierBorderWarn**                 | _none_                          | Border for Warn notification                                 |
-| **SnacksNotifierBorderDebug**       | _none_ | Border for Debug notification                                                   |
-| **SnacksNotifierBorderError**       | _none_ | Border for Error notification                                                   |
-| **SnacksNotifierBorderTrace**    | _none_ | Border for Trace notification                                                   |
-| **SnacksNotifierFooterInfo** | _DiagnosticInfo_ | Footer for Info notification                                                   |
-| **SnacksNotifierFooterWarn**     | _DiagnosticWarn_                        | Footer for Warn notification                                                   |
-| **SnacksNotifierFooterDebug**        | _DiagnosticHint_ | Footer for Debug notification                                                   |
-| **SnacksNotifierFooterError**  | _DiagnosticError_ | Footer for Error notification                                                   |
-| **SnacksNotifierFooterTrace**       | _DiagnosticHint_ | Footer for Trace notification                                                   |
+| Highlight Group               | Default Group     | Description                    |
+| ----------------------------- | ----------------- | ------------------------------ |
+| **SnacksNormal**              | _NormalFloat_     | Normal for the float window    |
+| **SnacksWinBar**              | _Title_           | Title of the window            |
+| **SnacksBackdrop**            | _none_            | Backdrop                       |
+| **SnacksNormalNC**            | _NormalFloat_     | Normal for non-current windows |
+| **SnacksWinBarNC**            | _SnacksWinBar_    | Title for non-current windows  |
+| **SnacksNotifierInfo**        | _none_            | Notification window for Info   |
+| **SnacksNotifierWarn**        | _none_            | Notification window for Warn   |
+| **SnacksNotifierDebug**       | _none_            | Notification window for Debug  |
+| **SnacksNotifierError**       | _none_            | Notification window for Error  |
+| **SnacksNotifierTrace**       | _none_            | Notification window for Trace  |
+| **SnacksNotifierIconInfo**    | _none_            | Icon for Info notification     |
+| **SnacksNotifierIconWarn**    | _none_            | Icon for Warn notification     |
+| **SnacksNotifierIconDebug**   | _none_            | Icon for Debug notification    |
+| **SnacksNotifierIconError**   | _none_            | Icon for Error notification    |
+| **SnacksNotifierIconTrace**   | _none_            | Icon for Trace notification    |
+| **SnacksNotifierTitleInfo**   | _none_            | Title for Info notification    |
+| **SnacksNotifierTitleWarn**   | _none_            | Title for Warn notification    |
+| **SnacksNotifierTitleDebug**  | _none_            | Title for Debug notification   |
+| **SnacksNotifierTitleError**  | _none_            | Title for Error notification   |
+| **SnacksNotifierTitleTrace**  | _none_            | Title for Trace notification   |
+| **SnacksNotifierBorderInfo**  | _none_            | Border for Info notification   |
+| **SnacksNotifierBorderWarn**  | _none_            | Border for Warn notification   |
+| **SnacksNotifierBorderDebug** | _none_            | Border for Debug notification  |
+| **SnacksNotifierBorderError** | _none_            | Border for Error notification  |
+| **SnacksNotifierBorderTrace** | _none_            | Border for Trace notification  |
+| **SnacksNotifierFooterInfo**  | _DiagnosticInfo_  | Footer for Info notification   |
+| **SnacksNotifierFooterWarn**  | _DiagnosticWarn_  | Footer for Warn notification   |
+| **SnacksNotifierFooterDebug** | _DiagnosticHint_  | Footer for Debug notification  |
+| **SnacksNotifierFooterError** | _DiagnosticError_ | Footer for Error notification  |
+| **SnacksNotifierFooterTrace** | _DiagnosticHint_  | Footer for Trace notification  |
 
 <!-- hl_end -->
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Install the plugin with your package manager:
 
 > [!tip]
 > If you don't need these plugins, you can disable them, or skip `setup` altogether.
+> ![tip]
+> It' a good idea to run `:checkhealth snacks` to see if everything is set up correctly.
 
 ```lua
 {

--- a/doc/snacks-init.txt
+++ b/doc/snacks-init.txt
@@ -20,18 +20,18 @@ Table of Contents                              *snacks-init-table-of-contents*
     ---@field notifier? snacks.notifier.Config | { enabled: boolean }
     ---@field quickfile? { enabled: boolean }
     ---@field statuscolumn? snacks.statuscolumn.Config  | { enabled: boolean }
+    ---@field styles? table<string, snacks.win.Config>
     ---@field terminal? snacks.terminal.Config
     ---@field toggle? snacks.toggle.Config
-    ---@field styles? table<string, snacks.win.Config>
     ---@field win? snacks.win.Config
     ---@field words? snacks.words.Config
     {
       styles = {},
-      bigfile = { enabled = true },
-      notifier = { enabled = true },
-      quickfile = { enabled = true },
-      statuscolumn = { enabled = true },
-      words = { enabled = true },
+      bigfile = { enabled = false },
+      notifier = { enabled = false },
+      quickfile = { enabled = false },
+      statuscolumn = { enabled = false },
+      words = { enabled = false },
     }
 <
 
@@ -41,9 +41,9 @@ Table of Contents                              *snacks-init-table-of-contents*
 
 >lua
     ---@class Snacks
-    ---@field config snacks.config
     ---@field bigfile snacks.bigfile
     ---@field bufdelete snacks.bufdelete
+    ---@field config snacks.config
     ---@field debug snacks.debug
     ---@field git snacks.git
     ---@field gitbrowse snacks.gitbrowse
@@ -51,6 +51,7 @@ Table of Contents                              *snacks-init-table-of-contents*
     ---@field notifier snacks.notifier
     ---@field notify snacks.notify
     ---@field quickfile snacks.quickfile
+    ---@field health snacks.health
     ---@field rename snacks.rename
     ---@field statuscolumn snacks.statuscolumn
     ---@field terminal snacks.terminal

--- a/doc/snacks-statuscolumn.txt
+++ b/doc/snacks-statuscolumn.txt
@@ -13,6 +13,7 @@ Table of Contents                      *snacks-statuscolumn-table-of-contents*
 
 >lua
     ---@class snacks.statuscolumn.Config
+    ---@field enabled? boolean
     {
       left = { "mark", "sign" }, -- priority of signs on the left (high to low)
       right = { "fold", "git" }, -- priority of signs on the right (high to low)

--- a/docs/init.md
+++ b/docs/init.md
@@ -12,18 +12,18 @@
 ---@field notifier? snacks.notifier.Config | { enabled: boolean }
 ---@field quickfile? { enabled: boolean }
 ---@field statuscolumn? snacks.statuscolumn.Config  | { enabled: boolean }
+---@field styles? table<string, snacks.win.Config>
 ---@field terminal? snacks.terminal.Config
 ---@field toggle? snacks.toggle.Config
----@field styles? table<string, snacks.win.Config>
 ---@field win? snacks.win.Config
 ---@field words? snacks.words.Config
 {
   styles = {},
-  bigfile = { enabled = true },
-  notifier = { enabled = true },
-  quickfile = { enabled = true },
-  statuscolumn = { enabled = true },
-  words = { enabled = true },
+  bigfile = { enabled = false },
+  notifier = { enabled = false },
+  quickfile = { enabled = false },
+  statuscolumn = { enabled = false },
+  words = { enabled = false },
 }
 ```
 
@@ -31,9 +31,9 @@
 
 ```lua
 ---@class Snacks
----@field config snacks.config
 ---@field bigfile snacks.bigfile
 ---@field bufdelete snacks.bufdelete
+---@field config snacks.config
 ---@field debug snacks.debug
 ---@field git snacks.git
 ---@field gitbrowse snacks.gitbrowse
@@ -41,6 +41,7 @@
 ---@field notifier snacks.notifier
 ---@field notify snacks.notify
 ---@field quickfile snacks.quickfile
+---@field health snacks.health
 ---@field rename snacks.rename
 ---@field statuscolumn snacks.statuscolumn
 ---@field terminal snacks.terminal

--- a/docs/statuscolumn.md
+++ b/docs/statuscolumn.md
@@ -6,6 +6,7 @@
 
 ```lua
 ---@class snacks.statuscolumn.Config
+---@field enabled? boolean
 {
   left = { "mark", "sign" }, -- priority of signs on the left (high to low)
   right = { "fold", "git" }, -- priority of signs on the right (high to low)

--- a/lua/snacks/docs.lua
+++ b/lua/snacks/docs.lua
@@ -309,7 +309,7 @@ function M.write(name, lines)
 end
 
 function M._build()
-  local skip = { "docs" }
+  local skip = { "docs", "health" }
   for file, t in vim.fs.dir("lua/snacks", { depth = 1 }) do
     local name = vim.fn.fnamemodify(file, ":t:r")
     if t == "file" and not vim.tbl_contains(skip, name) then

--- a/lua/snacks/health.lua
+++ b/lua/snacks/health.lua
@@ -1,0 +1,52 @@
+---@class snacks.health
+---@field ok fun(msg: string)
+---@field warn fun(msg: string)
+---@field error fun(msg: string)
+---@field info fun(msg: string)
+---@field start fun(msg: string)
+local M = setmetatable({}, {
+  __index = function(M, k)
+    return function(msg)
+      return require("vim.health")[k](M.prefix .. msg)
+    end
+  end,
+})
+
+M.prefix = ""
+
+M.needs_setup = { "bigfile", "notifier", "statuscolumn", "words", "quickfile" }
+
+function M.check()
+  M.prefix = ""
+  M.start("Snacks")
+  if Snacks.did_setup then
+    M.ok("setup called")
+  else
+    M.error("setup not called")
+  end
+  local root = debug.getinfo(1, "S").source:match("@(.*)")
+  root = vim.fn.fnamemodify(root, ":h")
+  for file, t in vim.fs.dir(root, { depth = 1 }) do
+    local name = file:match("(.*)%.lua")
+    if t == "file" and name and not vim.tbl_contains({ "init", "docs", "health" }, name) then
+      local mod = Snacks[name] --[[@as {health?: fun()}]]
+      local opts = Snacks.config[name] or {} --[[@as {enabled?: boolean}]]
+      local needs_setup = vim.tbl_contains(M.needs_setup, name)
+      if needs_setup or mod.health then
+        M.prefix = ("`Snacks.%s` "):format(name)
+        if needs_setup then
+          if opts.enabled then
+            M.ok("setup {enabled}")
+          else
+            M.warn("setup {disabled}")
+          end
+        end
+        if mod.health then
+          mod.health()
+        end
+      end
+    end
+  end
+end
+
+return M

--- a/lua/snacks/init.lua
+++ b/lua/snacks/init.lua
@@ -1,7 +1,7 @@
 ---@class Snacks
----@field config snacks.config
 ---@field bigfile snacks.bigfile
 ---@field bufdelete snacks.bufdelete
+---@field config snacks.config
 ---@field debug snacks.debug
 ---@field git snacks.git
 ---@field gitbrowse snacks.gitbrowse
@@ -9,6 +9,7 @@
 ---@field notifier snacks.notifier
 ---@field notify snacks.notify
 ---@field quickfile snacks.quickfile
+---@field health snacks.health
 ---@field rename snacks.rename
 ---@field statuscolumn snacks.statuscolumn
 ---@field terminal snacks.terminal
@@ -34,18 +35,18 @@ _G.Snacks = M
 ---@field notifier? snacks.notifier.Config | { enabled: boolean }
 ---@field quickfile? { enabled: boolean }
 ---@field statuscolumn? snacks.statuscolumn.Config  | { enabled: boolean }
+---@field styles? table<string, snacks.win.Config>
 ---@field terminal? snacks.terminal.Config
 ---@field toggle? snacks.toggle.Config
----@field styles? table<string, snacks.win.Config>
 ---@field win? snacks.win.Config
 ---@field words? snacks.words.Config
 local config = {
   styles = {},
-  bigfile = { enabled = true },
-  notifier = { enabled = true },
-  quickfile = { enabled = true },
-  statuscolumn = { enabled = true },
-  words = { enabled = true },
+  bigfile = { enabled = false },
+  notifier = { enabled = false },
+  quickfile = { enabled = false },
+  statuscolumn = { enabled = false },
+  words = { enabled = false },
 }
 
 ---@class snacks.config: snacks.Config
@@ -78,8 +79,19 @@ function M.config.style(name, defaults)
   config.styles[name] = vim.tbl_deep_extend("force", vim.deepcopy(defaults), config.styles[name] or {})
 end
 
+M.did_setup = false
+
 ---@param opts snacks.Config?
 function M.setup(opts)
+  if M.did_setup then
+    return vim.notify("snacks.nvim is already setup", vim.log.levels.ERROR, { title = "snacks.nvim" })
+  end
+  M.did_setup = true
+  opts = opts or {}
+  -- enable all by default when config is passed
+  for k in pairs(opts) do
+    opts[k].enabled = opts[k].enabled == nil or opts[k].enabled
+  end
   config = vim.tbl_deep_extend("force", config, opts or {})
 
   if vim.fn.has("nvim-0.9.4") ~= 1 then

--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -195,4 +195,10 @@ function M.log_file(opts)
   return M.open(opts)
 end
 
+---@private
+function M.health()
+  local ok = vim.fn.executable("lazygit") == 1
+  Snacks.health[ok and "ok" or "error"](("{lazygit} %sinstalled"):format(ok and "" or "not "))
+end
+
 return M

--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -311,8 +311,14 @@ function N:start()
   )
 end
 
+local health_msg = false
+
 ---@param opts snacks.notifier.Notif.opts
 function N:add(opts)
+  if opts.checkhealth then
+    health_msg = true
+    return
+  end
   local now = ts()
   local notif = vim.deepcopy(opts) --[[@as snacks.notifier.Notif]]
   notif.msg = notif.msg or ""
@@ -659,6 +665,20 @@ end
 ---@param opts? snacks.notifier.history
 function M.show_history(opts)
   return notifier:show_history(opts)
+end
+
+---@private
+function M.health()
+  health_msg = false
+  vim.notify("", nil, { checkhealth = true })
+  vim.wait(500, function()
+    return health_msg
+  end, 10)
+  if health_msg then
+    Snacks.health.ok("is ready")
+  else
+    Snacks.health.error("is not ready")
+  end
 end
 
 return M

--- a/lua/snacks/statuscolumn.lua
+++ b/lua/snacks/statuscolumn.lua
@@ -9,6 +9,7 @@ local M = setmetatable({}, {
 })
 
 ---@class snacks.statuscolumn.Config
+---@field enabled? boolean
 local defaults = {
   left = { "mark", "sign" }, -- priority of signs on the left (high to low)
   right = { "fold", "git" }, -- priority of signs on the right (high to low)
@@ -213,6 +214,16 @@ function M.get()
   end
 
   return table.concat(components, "")
+end
+
+---@private
+function M.health()
+  local ready = vim.o.statuscolumn:find("snacks.statuscolumn", 1, true)
+  if config.enabled and not ready then
+    Snacks.health.warn(("is not configured\n- `vim.o.statuscolumn = %q`"):format(vim.o.statuscolumn))
+  elseif not config.enabled and ready then
+    Snacks.health.ok(("is manually configured\n- `vim.o.statuscolumn = %q`"):format(vim.o.statuscolumn))
+  end
 end
 
 return M

--- a/lua/snacks/terminal.lua
+++ b/lua/snacks/terminal.lua
@@ -201,4 +201,16 @@ function M.colorize()
   vim.api.nvim_create_autocmd("TermEnter", { buffer = buf, command = "stopinsert" })
 end
 
+---@private
+function M.health()
+  local cmd = M.parse(vim.o.shell)
+  local ok = cmd[1] and (vim.fn.executable(cmd[1]) == 1)
+  local msg = ("shell %s\n- `vim.o.shell`: %s\n- `parsed`: %s"):format(
+    ok and "configured" or "not found",
+    vim.o.shell,
+    vim.inspect(cmd)
+  )
+  Snacks.health[ok and "ok" or "error"](msg)
+end
+
 return M

--- a/lua/snacks/toggle.lua
+++ b/lua/snacks/toggle.lua
@@ -196,4 +196,10 @@ function M.diagnostics(opts)
   }, opts)
 end
 
+---@private
+function M.health()
+  local ok = pcall(require, "which-key")
+  Snacks.health[ok and "ok" or "warn"](("{which-key} is %s"):format(ok and "installed" or "not installed"))
+end
+
 return M


### PR DESCRIPTION
## Description

With this change, plugins are no longer enabled by default.
The are enabled when passing any options for the plugin, or by explicitely setting `enabled = true`.

This PR also adds a bunch of healthchecks `:checkhealth snacks`

## Screenshots

![image](https://github.com/user-attachments/assets/352dc035-8a09-48d6-875b-888b0ded531b)

