### PR TITLE
fix(win): delay when closing windows

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -395,6 +395,7 @@ function M:show()
       opts[2] = nil
       opts.mode = nil
       opts.buffer = self.buf
+      opts.nowait = true
       local rhs = spec[2]
       if type(rhs) == "function" then
         rhs = function()


### PR DESCRIPTION
## Description
`vim.keymap.set` was missing the `nowait = true`

