### PR TITLE
fix(notifier): no gap in border without title/icon

### DIFF
--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -144,10 +144,13 @@ end
 N.styles = {
   -- style using border title
   compact = function(buf, notif, ctx)
-    ctx.opts.title = {
-      { " " .. vim.trim(notif.icon .. " " .. (notif.title or "")) .. " ", ctx.hl.title },
-    }
-    ctx.opts.title_pos = "center"
+    local title_content = vim.trim(notif.icon .. " " .. (notif.title or ""))
+    if title_content ~= "" then
+      ctx.opts.title = {
+        { " " .. title_content .. " ", ctx.hl.title },
+      }
+      ctx.opts.title_pos = "center"
+    end
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(notif.msg, "\n"))
   end,
   minimal = function(buf, notif, ctx)

--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -144,11 +144,9 @@ end
 N.styles = {
   -- style using border title
   compact = function(buf, notif, ctx)
-    local title_content = vim.trim(notif.icon .. " " .. (notif.title or ""))
-    if title_content ~= "" then
-      ctx.opts.title = {
-        { " " .. title_content .. " ", ctx.hl.title },
-      }
+    local title = vim.trim(notif.icon .. " " .. (notif.title or ""))
+    if title ~= "" then
+      ctx.opts.title = { { " " .. title .. " ", ctx.hl.title } }
       ctx.opts.title_pos = "center"
     end
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(notif.msg, "\n"))


### PR DESCRIPTION
## Description
Don't put padding with no title and no icon, so that there is no gap in the border.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #84.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

