### PR TITLE
fix(dashboard): disable `vim.wo.colorcolumn`

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -142,6 +142,7 @@ Snacks.config.style("dashboard", {
     undofile = false,
   },
   wo = {
+    colorcolumn = "",
     cursorcolumn = false,
     cursorline = false,
     list = false,


### PR DESCRIPTION
## Description

If `colorcolumn` is set, e.g.:

```lua
vim.opt.colorcolumn = { 80, 100 } -- Guide columns positions
```

The dashboard window shows the columns:

![imagen](https://github.com/user-attachments/assets/72ee34e2-3b26-4940-8cdd-13dafdd11662)

This PR add the missing window option
