### PR TITLE
refactor(dashboard): change persisted.nvim load session command

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -727,7 +727,7 @@ M.sections = {}
 function M.sections.session(item)
   local plugins = {
     { "persistence.nvim", ":lua require('persistence').load()" },
-    { "persisted.nvim", ":SessionLoad" },
+    { "persisted.nvim", ":lua require('persisted').load()" },
     { "neovim-session-manager", ":SessionManager load_current_dir_session" },
     { "possession.nvim", ":PossessionLoadCwd" },
     { "mini.sessions", ":lua require('mini.sessions').read('local')" },


### PR DESCRIPTION
## Description

Firstly, thank you for integrating persisted.nvim in the dashboard out of the box.

This PR changes the command to load a persisted.nvim session. This accounts for users potentially not having `SessionLoad` available to them if they lazy load their dashboard and don't have `cmd = { "SessionLoad" }` setup.

## Related Issue(s)

N/A

## Screenshots

N/A

