### PR TITLE
fix(gitbrowse): fix the regex in url_patterns

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -38,11 +38,11 @@ local defaults = {
     { "%.git$"                            , "" },
   },
   url_patterns = {
-    ["github.com"] = {
+    ["github%.com"] = {
       branch = "/tree/{branch}",
       file = "/blob/{branch}/{file}#L{line}",
     },
-    ["gitlab.com"] = {
+    ["gitlab%.com"] = {
       branch = "/-/tree/{branch}",
       file = "/-/blob/{branch}/{file}#L{line}",
     },


### PR DESCRIPTION
## Description

The `remote` is used as a regex pattern, so the dot in the `"github.com"` means any character. This PR correct the regexes in default `url_patterns`.

https://github.com/folke/snacks.nvim/blob/aa38175c002555aded511b6787380ad887665680/lua/snacks/gitbrowse.lua#L40-L49

https://github.com/folke/snacks.nvim/blob/aa38175c002555aded511b6787380ad887665680/lua/snacks/gitbrowse.lua#L68-L72


Test code:

```lua
print(require("snacks").gitbrowse.get_url("https://githubacom.com/folke/snacks.nvim"))
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

**Before**
![image](https://github.com/user-attachments/assets/899e8312-2e9d-44ed-92c1-e3b28cedc06c)

**After**
![image](https://github.com/user-attachments/assets/fc5610a9-8977-4369-aff2-861730083308)


