### PR TITLE
fix(git): recognize git worktrees as git repository

### DIFF
--- a/lua/snacks/git.lua
+++ b/lua/snacks/git.lua
@@ -20,7 +20,7 @@ function M.get_root(path)
   path = path == "" and (vim.uv or vim.loop).cwd() or path
   local git_root ---@type string?
   for dir in vim.fs.parents(path) do
-    if vim.uv.fs_stat(dir .. "/.git") ~= nil then
+    if vim.uv.fs_stat(dir .. "/.git") then
       git_root = dir
       break
     end

--- a/lua/snacks/git.lua
+++ b/lua/snacks/git.lua
@@ -20,7 +20,7 @@ function M.get_root(path)
   path = path == "" and (vim.uv or vim.loop).cwd() or path
   local git_root ---@type string?
   for dir in vim.fs.parents(path) do
-    if vim.fn.isdirectory(dir .. "/.git") == 1 or vim.fn.filereadable(dir .. "/.git") == 1 then
+    if vim.uv.fs_stat(dir .. "/.git") ~= nil then
       git_root = dir
       break
     end

--- a/lua/snacks/git.lua
+++ b/lua/snacks/git.lua
@@ -20,7 +20,7 @@ function M.get_root(path)
   path = path == "" and (vim.uv or vim.loop).cwd() or path
   local git_root ---@type string?
   for dir in vim.fs.parents(path) do
-    if vim.fn.isdirectory(dir .. "/.git") == 1 then
+    if vim.fn.isdirectory(dir .. "/.git") == 1 or vim.fn.filereadable(dir .. "/.git") == 1 then
       git_root = dir
       break
     end


### PR DESCRIPTION
## Description

`get_root` recognizes git worktrees as git repos

## Related Issue(s)

- Fixes #115

