### PR TITLE
feat(gitbrowse): add separate getremotes

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -90,7 +90,13 @@ function M.open(opts)
 end
 
 ---@param opts? snacks.gitbrowse.Config
-function M._open(opts)
+function M.getremotes(opts)
+  pcall(M._getremotes, opts) -- errors are handled with notifications
+end
+
+---@param opts? snacks.gitbrowse.Config
+---@return {name: string, url: string}[] A list of remotes with names and resolved URLs.
+function M._getremotes(opts)
   opts = Snacks.config.get("gitbrowse", defaults, opts)
   local file = vim.api.nvim_buf_get_name(0) ---@type string?
   file = file and (uv.fs_stat(file) or {}).type == "file" and vim.fs.normalize(file) or nil
@@ -133,6 +139,14 @@ function M._open(opts)
       end
     end
   end
+
+  return remotes
+end
+
+---@param opts? snacks.gitbrowse.Config
+function M._open(opts)
+  opts = Snacks.config.get("gitbrowse", defaults, opts)
+  local remotes = M._getremotes(opts)
 
   local function open(remote)
     if remote then


### PR DESCRIPTION
## Description

Similarly to opening in github, I would like to be able to yank the current url. For that I thought that allowing to get the remotes would be useful. 

## Related Issue(s)

(not filed / tried) In the yank case at least for me, it'd be nicer to yank the file url without the line and in visual mode to yank the current line or range. I can yank the current file with this, but it's a bit inconvenient:

```lua
print(Snacks.gitbrowse._getremotes({ url_patterns = { ["github%.com"] = { file = "/blob/{branch}/{file}" } } })[1].url)
```


## Screenshots

<!-- Add screenshots of the changes if applicable. -->

