### PR TITLE
feat(gitbrowse): open commit when word is valid hash

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -19,7 +19,7 @@ local defaults = {
     end
     vim.ui.open(url)
   end,
-  ---@type "repo" | "branch" | "file"
+  ---@type "repo" | "branch" | "file" | "commit"
   what = "file", -- what to open. not all remotes support all types
   -- patterns to transform remotes to an actual URL
   -- stylua: ignore
@@ -41,10 +41,12 @@ local defaults = {
     ["github%.com"] = {
       branch = "/tree/{branch}",
       file = "/blob/{branch}/{file}#L{line}",
+      commit = "/commit/{commit}",
     },
     ["gitlab%.com"] = {
       branch = "/-/tree/{branch}",
       file = "/-/blob/{branch}/{file}#L{line}",
+      commit = "/-/commit/{commit}",
     },
   },
 }
@@ -84,6 +86,16 @@ local function system(cmd, err)
   return vim.split(vim.trim(proc), "\n")
 end
 
+---@param hash string
+---@return boolean
+local function is_valid_commit_hash(hash)
+  if not hash:match("^[a-fA-F0-9]+$") then
+    return false
+  end
+  system({ "git", "rev-parse", "--verify", hash }, "Invalid commit hash")
+  return true
+end
+
 ---@param opts? snacks.gitbrowse.Config
 function M.open(opts)
   pcall(M._open, opts) -- errors are handled with notifications
@@ -95,27 +107,35 @@ function M._open(opts)
   local file = vim.api.nvim_buf_get_name(0) ---@type string?
   file = file and (uv.fs_stat(file) or {}).type == "file" and vim.fs.normalize(file) or nil
   local cwd = file and vim.fn.fnamemodify(file, ":h") or vim.fn.getcwd()
-  local fields = {
-    branch = system({ "git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD" }, "Failed to get current branch")[1],
-    file = file and system({ "git", "-C", cwd, "ls-files", "--full-name", file }, "Failed to get git file path")[1],
-    line = nil,
-  }
+  local fields
 
-  -- Get visual selection range if in visual mode
-  if vim.fn.mode() == "v" or vim.fn.mode() == "V" then
-    local start_line = vim.fn.line("v")
-    local end_line = vim.fn.line(".")
-    -- Ensure start_line is always the smaller number
-    if start_line > end_line then
-      start_line, end_line = end_line, start_line
-    end
-    fields.line = file and start_line .. "-L" .. end_line
+  local word = vim.fn.expand("<cword>")
+  if word and is_valid_commit_hash(word) then
+    opts.what = "commit"
+    fields = { commit = word }
   else
-    fields.line = file and vim.fn.line(".")
-  end
+    fields = {
+      branch = system({ "git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD" }, "Failed to get current branch")[1],
+      file = file and system({ "git", "-C", cwd, "ls-files", "--full-name", file }, "Failed to get git file path")[1],
+      line = nil,
+    }
 
-  opts.what = opts.what == "file" and not fields.file and "branch" or opts.what
-  opts.what = opts.what == "branch" and not fields.branch and "repo" or opts.what
+    -- Get visual selection range if in visual mode
+    if vim.fn.mode() == "v" or vim.fn.mode() == "V" then
+      local start_line = vim.fn.line("v")
+      local end_line = vim.fn.line(".")
+      -- Ensure start_line is always the smaller number
+      if start_line > end_line then
+        start_line, end_line = end_line, start_line
+      end
+      fields.line = file and start_line .. "-L" .. end_line
+    else
+      fields.line = file and vim.fn.line(".")
+    end
+
+    opts.what = opts.what == "file" and not fields.file and "branch" or opts.what
+    opts.what = opts.what == "branch" and not fields.branch and "repo" or opts.what
+  end
 
   local remotes = {} ---@type {name:string, url:string}[]
 

--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -87,12 +87,13 @@ local function system(cmd, err)
 end
 
 ---@param hash string
+---@param cwd string
 ---@return boolean
-local function is_valid_commit_hash(hash)
-  if not hash:match("^[a-fA-F0-9]+$") then
+local function is_valid_commit_hash(hash, cwd)
+  if not (hash:match("^[a-fA-F0-9]+$") and #hash >= 7) then
     return false
   end
-  system({ "git", "rev-parse", "--verify", hash }, "Invalid commit hash")
+  system({ "git", "-C", cwd, "rev-parse", "--verify", hash }, "Invalid commit hash")
   return true
 end
 
@@ -108,7 +109,7 @@ function M._open(opts)
   file = file and (uv.fs_stat(file) or {}).type == "file" and vim.fs.normalize(file) or nil
   local cwd = file and vim.fn.fnamemodify(file, ":h") or vim.fn.getcwd()
   local word = vim.fn.expand("<cword>")
-  local is_commit = is_valid_commit_hash(word)
+  local is_commit = is_valid_commit_hash(word, cwd)
   local fields = {
     branch = system({ "git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD" }, "Failed to get current branch")[1],
     file = file and system({ "git", "-C", cwd, "ls-files", "--full-name", file }, "Failed to get git file path")[1],

--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -108,11 +108,12 @@ function M._open(opts)
   file = file and (uv.fs_stat(file) or {}).type == "file" and vim.fs.normalize(file) or nil
   local cwd = file and vim.fn.fnamemodify(file, ":h") or vim.fn.getcwd()
   local word = vim.fn.expand("<cword>")
+  local is_commit = is_valid_commit_hash(word)
   local fields = {
     branch = system({ "git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD" }, "Failed to get current branch")[1],
     file = file and system({ "git", "-C", cwd, "ls-files", "--full-name", file }, "Failed to get git file path")[1],
     line = nil,
-    commit = is_valid_commit_hash(word) and word,
+    commit = is_commit and word,
   }
 
   -- Get visual selection range if in visual mode
@@ -128,11 +129,9 @@ function M._open(opts)
     fields.line = file and vim.fn.line(".")
   end
 
-  opts.what = is_valid_commit_hash(word) and "commit"
-    or opts.what == "commit" and not fields.commit and "file"
-    or opts.what
-  opts.what = not is_valid_commit_hash(word) and opts.what == "file" and not fields.file and "branch" or opts.what
-  opts.what = not is_valid_commit_hash(word) and opts.what == "branch" and not fields.branch and "repo" or opts.what
+  opts.what = is_commit and "commit" or opts.what == "commit" and not fields.commit and "file" or opts.what
+  opts.what = not is_commit and opts.what == "file" and not fields.file and "branch" or opts.what
+  opts.what = not is_commit and opts.what == "branch" and not fields.branch and "repo" or opts.what
 
   local remotes = {} ---@type {name:string, url:string}[]
 


### PR DESCRIPTION
## Description
`gitbrowse` opens commit when word under cursor is valid commit hash. Please check the Lua pattern for the commit hash in the validation function I used as I'm not confident as to if it covers all the cases. I only tested with `diffview` file history and `gitsigns` blame buffer as I don't use other tools.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #138.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

