### PR TITLE
feat(dashboard): make buffer not listed

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -146,6 +146,7 @@ Snacks.config.style("dashboard", {
   bo = {
     bufhidden = "wipe",
     buftype = "nofile",
+    buflisted = false,
     filetype = "snacks_dashboard",
     swapfile = false,
     undofile = false,


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Set the dashboard buffer to not listed for consistency with other dashboard plugins

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

