### PR TITLE
Add dashboard startuptime icon option

### DIFF
--- a/doc/snacks-dashboard.txt
+++ b/doc/snacks-dashboard.txt
@@ -706,8 +706,9 @@ installed.
 Add the startup section
 
 >lua
+    ---@param opts? {icon?:string}
     ---@return snacks.dashboard.Section?
-    Snacks.dashboard.sections.startup()
+    Snacks.dashboard.sections.startup(opts)
 <
 
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -637,8 +637,9 @@ Snacks.dashboard.sections.session(item)
 Add the startup section
 
 ```lua
+---@param opts? {icon?:string}
 ---@return snacks.dashboard.Section?
-Snacks.dashboard.sections.startup()
+Snacks.dashboard.sections.startup(opts)
 ```
 
 ### `Snacks.dashboard.sections.terminal()`

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1052,14 +1052,17 @@ function M.sections.terminal(opts)
 end
 
 --- Add the startup section
+---@param opts? {icon?:string}
 ---@return snacks.dashboard.Section?
-function M.sections.startup()
+function M.sections.startup(opts)
+  opts = opts or {}
   M.lazy_stats = M.lazy_stats and M.lazy_stats.startuptime > 0 and M.lazy_stats or require("lazy.stats").stats()
   local ms = (math.floor(M.lazy_stats.startuptime * 100 + 0.5) / 100)
+  local icon = opts.icon or '⚡ '
   return {
     align = "center",
     text = {
-      { "⚡ Neovim loaded ", hl = "footer" },
+      { icon .. "Neovim loaded ", hl = "footer" },
       { M.lazy_stats.loaded .. "/" .. M.lazy_stats.count, hl = "special" },
       { " plugins in ", hl = "footer" },
       { ms .. "ms", hl = "special" },


### PR DESCRIPTION
## Description

Adds an `icon` option to the dashboard `startup` section. So people (like me, who thinks an emoji in a bunch of nerdfonts is awkward) can change it easily. 

## Screenshots

<details>
<summary>Screenshots</summary>

Screenshot with a minimal config
![Snipaste_2024-12-07_22-08-42](https://github.com/user-attachments/assets/bf8c4754-3902-412d-83dc-f7efec77ee7f)

</details>
