### PR TITLE
fix(dashboard): add filetype to terminal sections

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1035,6 +1035,7 @@ function M.sections.terminal(opts)
         })
         local hl = opts.hl and hl_groups[opts.hl] or opts.hl or "SnacksDashboardTerminal"
         Snacks.util.wo(win, { winhighlight = "TermCursorNC:" .. hl .. ",NormalFloat:" .. hl })
+        Snacks.util.bo(buf, { filetype = Snacks.config.styles.dashboard.bo.filetype })
         local close = vim.schedule_wrap(function()
           stopped = true
           pcall(vim.api.nvim_win_close, win, true)


### PR DESCRIPTION
The intention is to make it easier to exclude the dashboard terminal from some plugins. For example, heirline.nvim sets winbar per-window to allow for winbar to be optionally disabled in non-floating windows, so this PR lets me disable heirline for snacks' dashboard terminals over other floating terminals.