### PR TITLE
fix(dashboard): don't open with startup option args

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1084,6 +1084,12 @@ function M.setup()
     return
   end
 
+  -- don't open dashboard if Neovim was invoked for example `nvim +'Octo issue edit 1'`
+  if vim.api.nvim_buf_get_name(0) ~= "" then
+    M.status.reason = "buffer has a name"
+    return
+  end
+
   -- there should be only one non-floating window and it should be the first buffer
   local wins = vim.tbl_filter(function(win)
     return vim.api.nvim_win_get_config(win).relative == ""


### PR DESCRIPTION
## Description
Don't open dashboard when Neovim opens with only startup option args. Took a look at how `dashboard.nvim` did it.
They also have an autocmd for `StdInReadPre`, but I tested with piping `echo "hello" | nvim` and it works as expected.

Not sure if it's the best solution, so feel free to make any additional changes or completely disregard for something more robust.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #221.
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

