### PR TITLE
fix(input): various minor visual fixes

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -78,6 +78,7 @@ function M.input(opts, on_confirm)
   end
 
   opts = Snacks.config.get("input", defaults, opts) --[[@as snacks.input.Opts]]
+  opts.prompt = opts.prompt:gsub(":%s*$", "")
 
   opts.win = Snacks.win.resolve("input", opts.win, {
     enter = true,

--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -45,6 +45,7 @@ Snacks.config.style("input", {
     winhighlight = "NormalFloat:SnacksInputNormal,FloatBorder:SnacksInputBorder,FloatTitle:SnacksInputTitle",
     cursorline = false,
   },
+  bo = { filetype = "snacks_input" },
   keys = {
     i_esc = { "<esc>", { "cmp_close", "cancel" }, mode = "i" },
     -- i_esc = { "<esc>", "stopinsert", mode = "i" },

--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -80,6 +80,10 @@ function M.input(opts, on_confirm)
 
   opts = Snacks.config.get("input", defaults, opts) --[[@as snacks.input.Opts]]
   opts.prompt = opts.prompt:gsub(":%s*$", "")
+  local statuscolumn = " %#" .. opts.icon_hl .. "#" .. opts.icon .. " "
+  if not opts.icon or opts.icon == "" then
+    statuscolumn = " "
+  end
 
   opts.win = Snacks.win.resolve("input", opts.win, {
     enter = true,
@@ -89,7 +93,7 @@ function M.input(opts, on_confirm)
       completefunc = "v:lua.Snacks.input.complete",
       omnifunc = "v:lua.Snacks.input.complete",
     },
-    wo = { statuscolumn = " %#" .. opts.icon_hl .. "#" .. opts.icon .. " " },
+    wo = { statuscolumn = statuscolumn },
     actions = {
       cancel = function(self)
         confirm()

--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -43,6 +43,7 @@ Snacks.config.style("input", {
   -- col = 0,
   wo = {
     winhighlight = "NormalFloat:SnacksInputNormal,FloatBorder:SnacksInputBorder,FloatTitle:SnacksInputTitle",
+    cursorline = false,
   },
   keys = {
     i_esc = { "<esc>", { "cmp_close", "cancel" }, mode = "i" },


### PR DESCRIPTION
## Description
1. Trim the trailing `:` from the prompt. The `:` is usually added to `vim.ui.input`, since it is by default displayed in the cmdline, where a separater is useful. As a window title, however, it serves no purpose; adding a `:` to a title is generally disrecommended.
2. Disable cursorline in the input window by default. Since the input window by default has a height of 1, the cursorline is not helpful at all, and only results in an inconsistently looking appearance. 
3. In case the user disables the icon by setting it to `""`, there is excess padding which looks weird (and also does not align with a window title set to `left`). Thus added a check for an empty string and adjust the padding accordingly.
4. Set `snacks_input` as default filetype for the input buffer, in line with how the other modules of `snacks` work.

All four changes are a separate commit, in case one of them is for some reason not desirable.

## Screenshots
before
![before](https://github.com/user-attachments/assets/fb49e269-ab1d-4510-a571-de3408ac57c3)

after
![after](https://github.com/user-attachments/assets/a0e34d34-c406-4213-8a89-a04d36419362)


