### PR TITLE
fix(input): missing padding if neither title nor icon positioned left

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -131,7 +131,7 @@ function M.input(opts, on_confirm)
       omnifunc = "v:lua.Snacks.input.complete",
     },
     wo = {
-      statuscolumn = next(statuscolumn) and " " .. table.concat(statuscolumn, " ") .. " " or nil,
+      statuscolumn = next(statuscolumn) and " " .. table.concat(statuscolumn, " ") .. " " or " ",
     },
     actions = {
       cancel = function(self)


### PR DESCRIPTION
## Description
The new`icon_pos` /`title_pos` options resulted in a situation where there is missing padding when neither is positioned left. This PR fixes this by falling back to `" "` as statuscolumn.

## Screenshots
before
<img alt="before" width=40% src="https://github.com/user-attachments/assets/e99a600f-0ab6-4319-a70d-24e3f658a0bb">

after
<img alt="after" width=40% src="https://github.com/user-attachments/assets/377f2157-32c6-40fb-a439-9af9141f00e7">


