### PR TITLE
feat(notifier): `Telescope notifier`

### DIFF
--- a/lua/snacks/init.lua
+++ b/lua/snacks/init.lua
@@ -134,6 +134,11 @@ function M.setup(opts)
       vim.notify = Snacks.notifier.notify
       return Snacks.notifier.notify(msg, level, o)
     end
+
+    local has_telescope = (vim.fn.exists("g:loaded_telescope") == 1)
+    if has_telescope then
+      require("telescope").load_extension("notifier")
+    end
   end
 end
 

--- a/lua/telescope/_extensions/notifier.lua
+++ b/lua/telescope/_extensions/notifier.lua
@@ -1,0 +1,98 @@
+local Snacks = require("snacks")
+
+local finders = require("telescope.finders")
+local pickers = require("telescope.pickers")
+local conf = require("telescope.config").values
+local action_state = require("telescope.actions.state")
+local actions = require("telescope.actions")
+local entry_display = require("telescope.pickers.entry_display")
+local previewers = require("telescope.previewers")
+
+local widths = {
+  time = nil,
+  title = nil,
+  icon = nil,
+  level = nil,
+  message = nil,
+}
+
+local displayer = entry_display.create({
+  separator = "",
+  items = {
+    { width = widths.time },
+    { width = 1 },
+    { width = widths.icon },
+    { width = 1 },
+    { width = widths.level },
+    { width = 1 },
+    { width = widths.title },
+    { width = 1 },
+    { remaining = true },
+  },
+})
+
+local telescope_notifications = function(opts)
+  local notifs = Snacks.notifier.get_history()
+  local reversed = {}
+  for i, notif in ipairs(notifs) do
+    local preview = notif._preview
+
+    if not preview then
+      notif._preview = {}
+      local prefix = Snacks.notifier.get_prefix(notif)
+      notif._preview.prefix = prefix
+      notif._preview.msg_title = vim.split(notif.msg, "\n")[1]
+    end
+
+    reversed[#notifs - i + 1] = notif
+  end
+  pickers
+    .new(opts, {
+      results_title = "Notifications",
+      prompt_title = "Filter Notifications",
+      finder = finders.new_table({
+        results = reversed,
+        entry_maker = function(notif)
+          return {
+            value = notif,
+            display = function(entry)
+              local t = { unpack(entry.value._preview.prefix) }
+              table.insert(t, { entry.value._preview.msg_title, "SnacksNotifierTitle" })
+              return displayer(t)
+            end,
+            ordinal = notif.msg,
+          }
+        end,
+      }),
+      sorter = conf.generic_sorter(opts),
+      attach_mappings = function(prompt_bufnr, map)
+        actions.select_default:replace(function()
+          actions.close(prompt_bufnr)
+          local selection = action_state.get_selected_entry()
+          if selection == nil then
+            return
+          end
+
+          local notif = selection.value
+          Snacks.notifier.show_preview(notif)
+        end)
+        return true
+      end,
+      previewer = previewers.new_buffer_previewer({
+        title = "Message",
+        define_preview = function(self, entry, status)
+          local notif = entry.value
+          vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(notif.msg, "\n"))
+          vim.api.nvim_set_option_value("wrap", true, { win = status.preview_win })
+          -- vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
+        end,
+      }),
+    })
+    :find()
+end
+
+return require("telescope").register_extension({
+  exports = {
+    notifier = telescope_notifications,
+  },
+})

--- a/lua/telescope/_extensions/notifier.lua
+++ b/lua/telescope/_extensions/notifier.lua
@@ -32,18 +32,9 @@ local displayer = entry_display.create({
 })
 
 local telescope_notifications = function(opts)
-  local notifs = Snacks.notifier.get_history()
+  local notifs = Snacks.notifier.get_history({ preview = true })
   local reversed = {}
   for i, notif in ipairs(notifs) do
-    local preview = notif._preview
-
-    if not preview then
-      notif._preview = {}
-      local prefix = Snacks.notifier.get_prefix(notif)
-      notif._preview.prefix = prefix
-      notif._preview.msg_title = vim.split(notif.msg, "\n")[1]
-    end
-
     reversed[#notifs - i + 1] = notif
   end
   pickers
@@ -84,6 +75,7 @@ local telescope_notifications = function(opts)
           local notif = entry.value
           vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, vim.split(notif.msg, "\n"))
           vim.api.nvim_set_option_value("wrap", true, { win = status.preview_win })
+          -- performance issues with filetype set
           -- vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
         end,
       }),


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
This is a port of https://github.com/rcarriga/nvim-notify?tab=readme-ov-file#viewing-history for the snacks notifier.
It simplifies navigating through notifications, as opposed to having them dumped into a single large file.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

https://github.com/user-attachments/assets/4969342c-c933-4295-b8ac-9e32e8bc93e8


