### PR TITLE
feat(notifier): `hide_from_history` option

### DIFF
--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -34,7 +34,7 @@ local uv = vim.uv or vim.loop
 ---@field style? snacks.notifier.style
 ---@field opts? fun(notif: snacks.notifier.Notif) -- dynamic opts
 ---@field hl? snacks.notifier.hl -- highlight overrides
----@field hide_from_history? boolean
+---@field history? boolean
 
 --- Notification object
 ---@class snacks.notifier.Notif: snacks.notifier.Notif.opts
@@ -396,7 +396,7 @@ function N:add(opts)
   if numlevel(notif.level) >= numlevel(self.opts.level) then
     self.queue[notif.id] = notif
   end
-  if not opts.hide_from_history then
+  if opts.history ~= false then
     self.history[notif.id] = notif
   end
   if self:is_blocking() then

--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -34,6 +34,7 @@ local uv = vim.uv or vim.loop
 ---@field style? snacks.notifier.style
 ---@field opts? fun(notif: snacks.notifier.Notif) -- dynamic opts
 ---@field hl? snacks.notifier.hl -- highlight overrides
+---@field hide_from_history? boolean
 
 --- Notification object
 ---@class snacks.notifier.Notif: snacks.notifier.Notif.opts
@@ -395,7 +396,9 @@ function N:add(opts)
   if numlevel(notif.level) >= numlevel(self.opts.level) then
     self.queue[notif.id] = notif
   end
-  self.history[notif.id] = notif
+  if not opts.hide_from_history then
+    self.history[notif.id] = notif
+  end
   if self:is_blocking() then
     pcall(function()
       self:process()


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Option to exclude some notifications from notification history,
for example, when dealing with spinners.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

