### PR TITLE
fix(indent): honor lead listchar

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -143,7 +143,8 @@ end
 ---@param indent number
 ---@param state snacks.indent.State
 local function get_extmark(indent, state)
-  local space = config.indent.blank or state.listchars.space or " "
+  local listchars = state.listchars
+  local space = config.indent.blank or listchars.lead or listchars.space or " "
   local key = indent .. ":" .. state.leftcol .. ":" .. state.shiftwidth .. ":" .. state.indent_offset .. ":" .. space
   if cache_extmarks[key] ~= nil then
     return cache_extmarks[key]


### PR DESCRIPTION
## Description

The lead listchar was not being honoured in https://github.com/folke/snacks.nvim/commit/0e150f5510e381753ddd18f29facba14716d5669, this pull request fixes that.

## Related Issue(s)

Fixes #291.

## Screenshots

Before the fix:

![image](https://github.com/user-attachments/assets/62c6ac53-1585-4285-a46d-db04013401e4)

After the fix:
![image](https://github.com/user-attachments/assets/089a9370-31ca-4190-ab50-74b0b2dc6184)


