### PR TITLE
feat(styles): exportable styles

### DIFF
--- a/lua/snacks/init.lua
+++ b/lua/snacks/init.lua
@@ -73,8 +73,10 @@ end
 --- Register a new window style config.
 ---@param name string
 ---@param defaults snacks.win.Config|{}
+---@return string
 function M.config.style(name, defaults)
   config.styles[name] = vim.tbl_deep_extend("force", vim.deepcopy(defaults), config.styles[name] or {})
+  return name
 end
 
 M.did_setup = false


### PR DESCRIPTION
To allow syntax like:

```lua
local mystyle = Snacks.config.style('...')

-- somewhere else
Snacks.win({
  style = mystyle
})
```

and improve code navigation (e.g. jumping using `gd`, as opposed to searching string, or not being sure of the exact name, ...)