### PR TITLE
fix(notifier): open history window with correct style

### DIFF
--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -456,7 +456,7 @@ function N:show_history(opts)
     vim.cmd("close")
     return
   end
-  local win = Snacks.win({ style = "notification.history", enter = true, show = false })
+  local win = Snacks.win({ style = "notification_history", enter = true, show = false })
   local buf = win:open_buf()
   opts = opts or {}
   if opts.reverse == nil then


### PR DESCRIPTION
## Description
This [commit](https://github.com/folke/snacks.nvim/commit/fd9ef30206185e3dd4d3294c74e2fd0dee9722d1) renamed the style for `history_notification`, but opening the window still used the old name.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

