### PR TITLE
chore(dashboard): replace 'hub status' with 'git status'

### DIFF
--- a/doc/snacks-dashboard.txt
+++ b/doc/snacks-dashboard.txt
@@ -267,7 +267,7 @@ A more advanced example using multiple panes
           enabled = function()
             return Snacks.git.get_root() ~= nil
           end,
-          cmd = "hub status --short --branch --renames",
+          cmd = "git status --short --branch --renames",
           height = 5,
           padding = 1,
           ttl = 5 * 60,

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -219,7 +219,7 @@ A more advanced example using multiple panes
       enabled = function()
         return Snacks.git.get_root() ~= nil
       end,
-      cmd = "hub status --short --branch --renames",
+      cmd = "git status --short --branch --renames",
       height = 5,
       padding = 1,
       ttl = 5 * 60,

--- a/docs/examples/dashboard.lua
+++ b/docs/examples/dashboard.lua
@@ -57,7 +57,7 @@ M.examples.advanced = {
       enabled = function()
         return Snacks.git.get_root() ~= nil
       end,
-      cmd = "hub status --short --branch --renames",
+      cmd = "git status --short --branch --renames",
       height = 5,
       padding = 1,
       ttl = 5 * 60,

--- a/docs/examples/dashboard.lua
+++ b/docs/examples/dashboard.lua
@@ -127,7 +127,7 @@ M.examples.github = {
         {
           icon = " ",
           title = "Git Status",
-          cmd = "hub --no-pager diff --stat -B -M -C",
+          cmd = "git --no-pager diff --stat -B -M -C",
           height = 10,
         },
       }


### PR DESCRIPTION


## Description

When copying the "advanced" or "github" examples for dashboard, there was error 'hub is not recognized' changing ```hub status --short --branch --renames``` to ```git status --short --branch --renames``` fixes that

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
![image](https://github.com/user-attachments/assets/f50c618b-37fd-4faa-b4a1-1046c47ed072)
![image](https://github.com/user-attachments/assets/067da57b-da33-477c-865e-30264a4c448c)

