### PR TITLE
chore(docs): updated gitbrowse keymap to support visual mode

### DIFF
--- a/docs/examples/init.lua
+++ b/docs/examples/init.lua
@@ -31,7 +31,7 @@ return {
     { "<leader>n",  function() Snacks.notifier.show_history() end, desc = "Notification History" },
     { "<leader>bd", function() Snacks.bufdelete() end, desc = "Delete Buffer" },
     { "<leader>cR", function() Snacks.rename.rename_file() end, desc = "Rename File" },
-    { "<leader>gB", function() Snacks.gitbrowse() end, desc = "Git Browse" },
+    { "<leader>gB", function() Snacks.gitbrowse() end, desc = "Git Browse", mode = { "n", "v" } },
     { "<leader>gb", function() Snacks.git.blame_line() end, desc = "Git Blame Line" },
     { "<leader>gf", function() Snacks.lazygit.log_file() end, desc = "Lazygit Current File History" },
     { "<leader>gg", function() Snacks.lazygit() end, desc = "Lazygit" },


### PR DESCRIPTION
## Description

Since https://github.com/folke/snacks.nvim/pull/89 was merged gitbrowse supports opening multiline URLs. 
This patch updates the keymap example docs to include visual mode so the feature works as expected.