### PR TITLE
fix(input): use correct highlight group for input prompt

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -120,7 +120,7 @@ function M.input(opts, on_confirm)
   if opts.icon_pos and (opts.icon or "") ~= "" then
     add(opts.icon, "SnacksInputIcon", opts.icon_pos)
   end
-  add(opts.prompt, "SnacksInputBorder", opts.prompt_pos)
+  add(opts.prompt, "SnacksInputTitle", opts.prompt_pos)
 
   if next(title) then
     table.insert(title, { " " })


### PR DESCRIPTION
I'm suspect this was just a typo... using the border highlight group rather than title.