### PR TITLE
fix(luadoc): add missing field (relative) to snacks.win.Config

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -34,6 +34,7 @@ M.meta = {
 ---@field height? number|fun(self:snacks.win):number Height of the window. Use <1 for relative height. 0 means full height. (default: 0.9)
 ---@field width? number|fun(self:snacks.win):number Width of the window. Use <1 for relative width. 0 means full width. (default: 0.9)
 ---@field minimal? boolean Disable a bunch of options to make the window minimal (default: true)
+---@field relative? "editor"|"win"|"cursor"|"mouse"
 ---@field position? "float"|"bottom"|"top"|"left"|"right"
 ---@field buf? number If set, use this buffer instead of creating a new one
 ---@field file? string If set, use this file instead of creating a new buffer


### PR DESCRIPTION
## Description

Just adding a missing field in luadoc

## Related Issue(s)

fixes weird `Missing required fields` diagnostics errors

## Screen Shots

<img width="852" alt="Screenshot 2024-12-21 at 23 21 16" src="https://github.com/user-attachments/assets/bf21c6d8-44a3-4585-ab02-2ca3c21ade3e" />
