### PR TITLE
fix(lazygit): enable boolean values in config

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -156,6 +156,9 @@ local function update_config(opts)
   local config = vim.tbl_deep_extend("force", { gui = { theme = theme } }, opts.config or {})
 
   local function yaml_val(val)
+    if type(val) == "boolean" then
+      return tostring(val)
+    end
     return type(val) == "string" and not val:find("^\"'`") and ("%q"):format(val) or val
   end
 


### PR DESCRIPTION
## Description

Using boolean value inside `config` resulted in error `attempt to concatenate a boolean value` inside `to_yaml` function.
This PR fixes it by converting boolean values to string

Example config:
```
lazygit = {
    config = {
        gui = {
            showFileTree = false,
        },
    },
},
```
## Related Issue(s)

## Screenshots
![image](https://github.com/user-attachments/assets/eea8eec6-2008-4ded-9222-6f7c9b9d4390)


