### PR TITLE
fix(toggle): only execute `self:_wk` when mapping exists

### DIFF
--- a/lua/snacks/toggle.lua
+++ b/lua/snacks/toggle.lua
@@ -116,8 +116,19 @@ function Toggle:map(keys, opts)
     self:toggle()
   end, opts)
   if self.opts.which_key then
-    Snacks.util.on_module("which-key", function()
-      self:_wk(keys, mode)
+    -- Needed so that it executes after `keymaps.lua` loads, otherwise it
+    -- wouldn't work as `Snacks.toggle.animate():map("<leader>ua") will be
+    -- evaluated during the parsing phase. Maybe there's a better way??
+    vim.schedule(function()
+      Snacks.util.on_module("which-key", function()
+        local modes = type(mode) == "string" and { mode } or mode
+        for _, m in ipairs(modes) do
+          local mapping = vim.fn.maparg(keys, m)
+          if mapping ~= "" then
+            self:_wk(keys, mode)
+          end
+        end
+      end)
     end)
   end
   return self


### PR DESCRIPTION
## Description
Currently when a user disables a key with `vim.keymap.del` in his personal configuration, the `which-key` menu still shows the mapping. This ensures that `self:_wk` function won't execute if the mapping doesn't exist.

If you're satisfied with this solution, please also remove the comment I included.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
No issues, rather a [LazyVim discussion](https://github.com/LazyVim/LazyVim/discussions/5240)
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
**Before**
![2024-12-23_20-08](https://github.com/user-attachments/assets/cbd045d1-3f22-4287-a17b-938f22554ce0)
**After**
![2024-12-23_20-09](https://github.com/user-attachments/assets/962a81d9-e04f-4fc7-b744-0bce2dc4933a)

