### PR TITLE
fix(dashboard): hash dashboard terminal section caching key to support long commands

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -943,10 +943,11 @@ function M.sections.terminal(opts)
       table.concat(type(cmd) == "table" and cmd or { cmd }, " "),
       uv.cwd(),
       opts.random and math.random(1, opts.random) or "",
-      "txt",
     }
+    local hashed_cache_key = vim.fn.sha256(table.concat(cache_parts, "."))
+
     local cache_dir = vim.fn.stdpath("cache") .. "/snacks"
-    local cache_file = cache_dir .. "/" .. table.concat(cache_parts, "."):gsub("[^%w%-_%.]", "_")
+    local cache_file = cache_dir .. "/" .. hashed_cache_key .. ".txt"
     local stat = uv.fs_stat(cache_file)
     local buf = vim.api.nvim_create_buf(false, true)
     local chan = vim.api.nvim_open_term(buf, {})


### PR DESCRIPTION
## Description

This change hashes the caching key for snacks dashboards terminal sections instead of building the key from the command itself. This allows for arbitrary length scripts to be given as a terminal section command instead of relying on existing commands in PATH. 

## Related Issue(s)

#379 

## Screenshots

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/77a376c1-75b6-4023-8984-efd590f66a68" />

