### PR TITLE
refactor(lazygit): break up oneliner

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -159,7 +159,15 @@ local function update_config(opts)
     if type(val) == "boolean" then
       return tostring(val)
     end
-    return type(val) == "string" and not val:find("^\"'`") and ("%q"):format(val) or val
+
+    if type(val) == "string" then
+      if val:find("^\"'`") then
+        return val
+      end
+      return ("%q"):format(val)
+    end
+
+    return val
   end
 
   local function to_yaml(tbl, indent)


### PR DESCRIPTION
Bugfix in my original PR already got merged with #377, so this PR is no longer technically needed.

However, I also added some minor (in my opinion) improvements for my patch. I've here rebased on the already merged bugfix so that this is ready to be merged. But it's up to you. Feel free to merge or close!

<details>
<summary>Original PR</summary>


## Why this change?

Boolean values are not properly handled for lazygit.

## What was changed?

- Refactored function `yaml_val` slightly.
- Added handling of val type boolean.

## Related Issue(s)

- Fixes #387


## Example

With this PR change, the boolean value for `overrideGpg` is now written properly, without a crash, to the lazygit config file at `~/.cache/nvim/lazygit-theme.yml`:

```yaml
gui:
  theme:
    activeBorderColor:
      - "#ff966c"
      - "bold"
    cherryPickedCommitBgColor:
      - "#c099ff"
    cherryPickedCommitFgColor:
      - "#82aaff"
    defaultFgColor:
      - "#c8d3f5"
    inactiveBorderColor:
      - "#589ed7"
    optionsTextColor:
      - "#82aaff"
    searchingActiveBorderColor:
      - "#ff966c"
      - "bold"
    selectedLineBgColor:
      - "#2d3f76"
    unstagedChangesColor:
      - "#c53b53"
  nerdFontsVersion: "3"
git:
  overrideGpg: true
os:
  editPreset: "nvim-remote"
```


</details>
