### PR TITLE
fix(win): backdrop having bright cell at top right

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -603,6 +603,7 @@ function M:drop()
     wo = {
       winhighlight = "Normal:" .. group,
       winblend = winblend,
+      colorcolumn = "",
     },
     bo = {
       buftype = "nofile",


### PR DESCRIPTION
## The bug
`backdrop` displays a bright cell at the top left. upon investigation, I figured out that it's created by the user's `colorcolumn` setting also being applied to the backdrop.

## The fix
Disable `colorcolumn` for the backdrop window.

## Screenshots

before
![Pasted image 2024-12-27 at 14 16 40@2x](https://github.com/user-attachments/assets/8495330e-cec3-46bb-ac8c-c009865a18e3)

after
![Pasted image 2024-12-27 at 14 17 14@2x](https://github.com/user-attachments/assets/2d0b46e5-a74a-4e01-aa01-e35536eb042c)


