### PR TITLE
fix(input): add autocmd to set buffer to unmodified to properly close when `expand=false`

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -215,6 +215,15 @@ function M.input(opts, on_confirm)
         end)
       end,
     })
+  else
+    -- Set buffer to unmodified regardless of `expand` value, so that it can
+    -- close even when `expand = false` from `win:close` method
+    vim.api.nvim_create_autocmd("TextChangedI", {
+      buffer = win.buf,
+      callback = function()
+        vim.bo[win.buf].modified = false
+      end,
+    })
   end
 
   return win


### PR DESCRIPTION
## Description
When `expand = false` the autocmd that sets the buffer to unmodified doesn't get executed. Create another autocmd to set the input buffer to unmodified, so that it can be properly closed by `win:close()` method.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #402
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

