### PR TITLE
fix(win): window position with border_offset logic

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -805,7 +805,7 @@ end
 
 --- Calculate the size of the border
 function M:border_size()
-  local border = self.opts.border and self.opts.border ~= "" and self.opts.border ~= "none" and self.opts.border
+  local border = self:has_border() and self.opts.border
   local full = border and not vim.tbl_contains({ "top", "right", "bottom", "left" }, border)
   ---@type { top: number, right: number, bottom: number, left: number }
   return {
@@ -878,7 +878,7 @@ function M:dim(parent)
   local function pos(p, s, ps, border_offset)
     p = type(p) == "function" and p(self) or p
     if not p then -- center
-      return math.floor((ps - s) / 2) + border_offset
+      return math.floor((ps - s - border_offset) / 2)
     end
     ---@cast p number
     if p < 0 then -- negative position
@@ -899,8 +899,8 @@ function M:dim(parent)
   ret.width = math.max(ret.width, self.opts.min_width or 0, 1)
   ret.width = math.min(ret.width, self.opts.max_width or ret.width, parent.width)
 
-  ret.row = pos(self.opts.row, ret.height, parent.height, border.top)
-  ret.col = pos(self.opts.col, ret.width, parent.width, border.left)
+  ret.row = pos(self.opts.row, ret.height, parent.height, border.top + border.bottom)
+  ret.col = pos(self.opts.col, ret.width, parent.width, border.left + border.right)
 
   return ret
 end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
The window position is not correctly centered when position is set to `float` and border isn't `none`. I have fixed this issue once [in the past](https://github.com/folke/snacks.nvim/pull/64) but it seems to have returned after the [dimension calculation rework](https://github.com/folke/snacks.nvim/commit/cc0b52872b99e3af7d80536e8a9cbc28d47e7f19). So I have applied the same logic to the new structure.

Thank you for your work and happy new year!

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

### Before
![before](https://github.com/user-attachments/assets/0c0d493e-1be5-4547-867e-d6a9897331e2)

### After
![after](https://github.com/user-attachments/assets/b298bdbb-b7ed-47e9-a428-92f4ca49819d)


