### PR TITLE
feat(terminal): add `toggle_all()` function

### DIFF
--- a/lua/snacks/terminal.lua
+++ b/lua/snacks/terminal.lua
@@ -158,6 +158,47 @@ function M.toggle(cmd, opts)
   return created and terminal or assert(terminal):toggle()
 end
 
+--- Toggle all terminal windows.
+--- If terminal windows exist:
+---   - If any are open, close all open terminals
+---   - If none are open, open all existing terminals
+--- If no terminals exist:
+---   - Create a terminal window
+--- `cmd` ans `opts` are optional and will be used
+--- to create a terminal if needed.
+---@param cmd? string | string[]
+---@param opts? snacks.terminal.Opts
+function M.toggle_all(cmd, opts)
+  local existing_terminals = {}
+  for _, term in pairs(terminals) do
+    if term and term:buf_valid() then
+      table.insert(existing_terminals, term)
+    end
+  end
+
+  if #existing_terminals > 0 then
+    local any_open = false
+    for _, term in ipairs(existing_terminals) do
+      if term:win_valid() then
+        any_open = true
+        break
+      end
+    end
+
+    if any_open then
+      for _, term in ipairs(existing_terminals) do
+        term:hide()
+      end
+    else
+      for _, term in ipairs(existing_terminals) do
+        term:show()
+      end
+    end
+  else
+    M.toggle(cmd, opts)
+  end
+end
+
 --- Parses a shell command into a table of arguments.
 --- - spaces inside quotes (only double quotes are supported) are preserved
 --- - backslash


### PR DESCRIPTION
## Description

I am enjoying the `terminal` plugin quite a lot - but when I worked with more than one terminal I found it annoying to have to close all terminal windows one by one and then reopen them one by one.

This PR adds a `toggle_all()` function to `terminal.lua` which opens all closed terminals (if any) or closes all opened terminals (if any). If no terminals have been opened, it will default to opening a new one (similar to the `get()` function).

Maybe this could be implemented in userland but I could not find a nice way to do that. It also helps a lot to have access to the `terminals` variable!

Let me know what you think!

## Screencast

In the following screencast I first toggle terminal 1 and then I toggle terminal 2.

I then use the newly added `toggle_all` function to close and open both terminals with the `Ctrl-\` keybind.

https://github.com/user-attachments/assets/1c5c0cc1-8ec3-42a6-a2b3-593637bb4ce5

