### PR TITLE
fix(win): incorrect negative position calculation when relative to cursor

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -876,15 +876,18 @@ function M:dim(parent)
   ---@param s number size
   ---@param ps number parent size
   local function pos(p, s, ps, border_from, border_to)
-    p = type(p) == "function" and p(self) or p
-    if not p then -- center
-      return math.floor((ps - s) / 2) - border_from
-    end
-    ---@cast p number
-    if p < 0 then -- negative position
-      return ps - s + p - border_from - border_to
-    elseif p < 1 and p > 0 then -- relative position
-      return math.floor(ps * p) + border_from
+    if self.opts.relative ~= "cursor" then
+      p = type(p) == "function" and p(self) or p
+      if not p then -- center
+        return math.floor((ps - s) / 2) - border_from
+      end
+      ---@cast p number
+      if p < 0 then -- negative position
+        return ps - s + p - border_from - border_to
+      elseif p < 1 and p > 0 then -- relative position
+        return math.floor(ps * p) + border_from
+      end
+      return p
     end
     return p
   end


### PR DESCRIPTION
When making a window relative to the cursor and setting either `row` or `col` to a negative integer it moves relative to the bottom right of its parent instead of moving relative to the cursor.

Example with input:
```lua
styles = {
  input = {
    relative = "cursor",
    width = 40,
    row = -3,
    col = 0,
    border = "single",
    title_pos = "left",
    },
},
```
Window opens like this:
![image](https://github.com/user-attachments/assets/6e3c772d-bfe1-4568-baaa-0b0bd58a828a)
When it should be like this:
![image](https://github.com/user-attachments/assets/38fd569d-467c-462b-a364-30f5eaf4ae47)


