### PR TITLE
fix(gitbrowse): update BitBucket line range URL pattern

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -59,7 +59,7 @@ local defaults = {
     },
     ["bitbucket%.org"] = {
       branch = "/src/{branch}",
-      file = "/src/{branch}/{file}#lines-{line_start}-L{line_end}",
+      file = "/src/{branch}/{file}#lines-{line_start}:{line_end}",
       commit = "/commits/{commit}",
     },
   },


### PR DESCRIPTION
## Description

Fix the git browse functionality for bitbucket. See the following for reference:

https://support.atlassian.com/bitbucket-cloud/docs/hyperlink-to-source-code-in-bitbucket/

https://stackoverflow.com/questions/59743484/link-to-specific-lines-of-code-in-stash-bitbucket
