### PR TITLE
fix(statuscolumn): use hl-FoldColumn for fold marks

### DIFF
--- a/lua/snacks/statuscolumn.lua
+++ b/lua/snacks/statuscolumn.lua
@@ -149,9 +149,9 @@ function M.line_signs(win, buf, lnum)
   -- Get fold signs
   vim.api.nvim_win_call(win, function()
     if vim.fn.foldclosed(lnum) >= 0 then
-      signs[#signs + 1] = { text = vim.opt.fillchars:get().foldclose or "", texthl = "Folded", type = "fold" }
+      signs[#signs + 1] = { text = vim.opt.fillchars:get().foldclose or "", texthl = "FoldColumn", type = "fold" }
     elseif config.folds.open and tostring(vim.treesitter.foldexpr(vim.v.lnum)):sub(1, 1) == ">" then
-      signs[#signs + 1] = { text = vim.opt.fillchars:get().foldopen or "", type = "fold" }
+      signs[#signs + 1] = { text = vim.opt.fillchars:get().foldopen or "", texthl = "FoldColumn", type = "fold" }
     end
   end)
 


### PR DESCRIPTION
## Description

Use FoldColumn highlight group for both foldopen and foldclose characters by default. This not only fixes an issue with `git_hl = false` not working in some cases but also makes the fold column behavior consistent when `git_hl = true`. Previously the highlighting of the fold column under closed fold characters could differ quite a lot depending on whether the block was new or not when `git_hl` was in use (see the `git_hl = true` screenshot in #446). Now only the character highlight should change, making the whole fold column look more uniform.

## Related Issue(s)

- Fixes #446.

## Screenshots

`git_hl = false`:
<img width="1440" alt="fix-githl-false" src="https://github.com/user-attachments/assets/67a94c3e-fdda-46f2-8390-515ad3eb15d1" />

`git_hl = true`:
<img width="1440" alt="fix-githl-true" src="https://github.com/user-attachments/assets/524124a9-e411-44f9-aafb-9c34b454fc38" />