### PR TITLE
fix(scratch): autowrite right buffer. Fixes #449.

### DIFF
--- a/lua/snacks/scratch.lua
+++ b/lua/snacks/scratch.lua
@@ -264,8 +264,10 @@ function M.open(opts)
     vim.api.nvim_create_autocmd("BufHidden", {
       group = vim.api.nvim_create_augroup("snacks_scratch_autowrite_" .. buf, { clear = true }),
       buffer = buf,
-      callback = function()
-        vim.cmd("silent! write")
+      callback = function(ev)
+        vim.api.nvim_buf_call(ev.buf, function()
+          vim.cmd("silent! write")
+        end)
       end,
     })
   end


### PR DESCRIPTION
## Description

When toggling scratch closed, it's possible for the active buffer to be something other than the scratch buffer.

This results in the autowrite behaviour triggering a `write` for whatever that active buffer was and leaving the scratch buffer as dirty.

## Related Issue(s)

- Fixes #449.

