### PR TITLE
feat(picker.git_diff): pick diff hunks

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -19,6 +19,14 @@ local M = {}
 ---@field smartcase? boolean use smartcase (defaults to true)
 ---@field ignorecase? boolean use ignorecase (defaults to true)
 
+--- This is only used when using `opts.preview = "preview"`.
+--- It's a previewer that shows a preview based on the item data.
+---@class snacks.picker.Item.preview
+---@field text string text to show in the preview buffer
+---@field ft? string optional filetype used tohighlight the preview buffer
+---@field extmarks? snacks.picker.Extmark[] additional extmarks
+---@field loc? boolean set to false to disable showing the item location in the preview
+
 ---@class snacks.picker.Item
 ---@field [string] any
 ---@field idx number
@@ -28,6 +36,7 @@ local M = {}
 ---@field pos? {[1]:number, [2]:number}
 ---@field end_pos? {[1]:number, [2]:number}
 ---@field highlights? snacks.picker.Highlight[][]
+---@field preview? snacks.picker.Item.preview
 
 ---@class snacks.picker.finder.Item: snacks.picker.Item
 ---@field idx? number

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -176,6 +176,12 @@ M.git_status = {
   },
 }
 
+M.git_diff = {
+  finder = "git_diff",
+  format = "git_diff",
+  preview = "git_diff",
+}
+
 ---@class snacks.picker.grep.Config: snacks.picker.proc.Config
 ---@field cmd? string
 ---@field hidden? boolean show hidden files

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -183,8 +183,8 @@ M.git_status = {
 
 M.git_diff = {
   finder = "git_diff",
-  format = "git_diff",
-  preview = "git_diff",
+  format = "file",
+  preview = "preview",
 }
 
 ---@class snacks.picker.grep.Config: snacks.picker.proc.Config

--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -46,13 +46,17 @@ function M.preview(ctx)
   ctx.preview:reset()
   local lines = vim.split(ctx.item.preview.text, "\n")
   vim.api.nvim_buf_set_lines(ctx.buf, 0, -1, false, lines)
-  ctx.preview:highlight({ ft = ctx.item.preview.ft })
+  if ctx.item.preview.ft then
+    ctx.preview:highlight({ ft = ctx.item.preview.ft })
+  end
   for _, extmark in ipairs(ctx.item.preview.extmarks or {}) do
     local e = vim.deepcopy(extmark)
     e.col, e.row = nil, nil
     vim.api.nvim_buf_set_extmark(ctx.buf, ns, (extmark.row or 1) - 1, extmark.col, e)
   end
-  ctx.preview:loc()
+  if ctx.item.preview.loc ~= false then
+    ctx.preview:loc()
+  end
 end
 
 ---@param ctx snacks.picker.preview.ctx

--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -100,4 +100,89 @@ function M.status(opts)
   }, opts or {}))
 end
 
+---@param opts snacks.picker.Config
+---@type snacks.picker.finder
+function M.diff(_opts)
+  return require("snacks.picker.core.picker").new({
+    finder = function()
+      local output = vim.system({ "git", "diff" }):wait().stdout
+      ---@type snacks.picker.finder.Item[]
+      local results = {}
+      ---@type string | nil
+      local filename = nil
+      ---@type number | nil
+      local linenumber = nil
+      ---@type string[]
+      local hunk = {}
+
+      for _, line in ipairs(vim.split(output or "", "\n")) do
+        -- new file
+        if vim.startswith(line, "diff") then
+          -- Start of a new hunk
+          if hunk[1] ~= nil then
+            ---@type snacks.picker.finder.Item
+            local item = { file = filename, pos = { linenumber, 0 }, raw_lines = hunk }
+            table.insert(results, item)
+          end
+
+          filename = line:match("^diff .* a/(.*) b/.*$")
+          linenumber = nil
+
+          hunk = {}
+        elseif vim.startswith(line, "@") then
+          if filename ~= nil and linenumber ~= nil and #hunk > 0 then
+            table.insert(results, { file = filename, pos = { linenumber, 0 }, raw_lines = hunk })
+            hunk = {}
+          end
+          -- Hunk header
+          -- @example "@@ -157,20 +157,6 @@ some content"
+          local linenr_str = string.match(line, "@@ %-.*,.* %+(.*),.* @@")
+          linenumber = tonumber(linenr_str)
+          hunk = {}
+          table.insert(hunk, line)
+        else
+          table.insert(hunk, line)
+        end
+      end
+      -- Add the last hunk to the table
+      if hunk[1] ~= nil and filename and linenumber and hunk then
+        table.insert(results, { file = filename, pos = { linenumber, 0 }, raw_lines = hunk })
+      end
+
+      local function get_diff_line_idx(lines)
+        for i, line in ipairs(lines) do
+          if vim.startswith(line, "-") or vim.startswith(line, "+") then
+            return i
+          end
+        end
+        return -1
+      end
+
+      for _, v in ipairs(results) do
+        local diff_line_idx = get_diff_line_idx(v.raw_lines)
+        diff_line_idx = math.max(
+          -- first line is header, next one is already handled
+          diff_line_idx - 2,
+          0
+        )
+        v.pos[1] = v.pos[1] + diff_line_idx
+      end
+
+      return results
+    end,
+    preview = function(ctx)
+      local buf = ctx.preview:scratch()
+
+      vim.bo[buf].modifiable = true
+      local lines = vim.split(table.concat(ctx.item.raw_lines, "\n"), "\n")
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      vim.bo[buf].modifiable = false
+
+      vim.bo[buf].filetype = "diff"
+
+      return true
+    end,
+  })
+end
+
 return M


### PR DESCRIPTION
Hi and thank you for the useful plugin!

## Description

I have been exploring the new picker api and got this git diff picker working which I think can be a nice addition to the existing set of picker. The key difference from the existing git_status picker is that it separates each hunk into its own item similar to `git add --patch` and when you select an item it takes you to the first hunk's line instead of top of the buffer. Before I put more effort into it I would like to see if this is a welcome change first.

This implementation can be further extended by allowing to support additional arguments such as `--staged`, `--ignore-all-space` or both.

A few points on current implementations. I could not get the per line parsing to work using the `require("snacks.picker.source.proc").proc(...)` and fell back to manually parsing the output after the command finished executing. There are likely many ways to improve it. I have been using it with telescope for about a year and so far it worked great. I think more people can benefit from this picker.

## Related Issue(s)

none

## Screenshots

Demo

https://github.com/user-attachments/assets/6cdfa48e-bc29-4194-8430-092fbc5f3dcd



