### PR TITLE
fix(zen): sync cursor with parent window

### DIFF
--- a/lua/snacks/zen.lua
+++ b/lua/snacks/zen.lua
@@ -170,6 +170,16 @@ function M.zen(opts)
   end
   opts.on_open(win)
 
+  -- sync cursor with the parent window
+  vim.api.nvim_create_autocmd("CursorMoved", {
+    group = win.augroup,
+    callback = function()
+      if win:win_valid() and vim.api.nvim_win_is_valid(parent_win) then
+        vim.api.nvim_win_set_cursor(parent_win, vim.api.nvim_win_get_cursor(win.win))
+      end
+    end,
+  })
+
   -- restore toggle states when window is closed
   vim.api.nvim_create_autocmd("WinClosed", {
     group = win.augroup,


### PR DESCRIPTION
## Description

The cursor position is now synchronized between the zen/zoom window and it's parent.

I'm not sure if this is the best way to achieve that. Initally I wanted to do set the parent's cursor position only when the zen buffer is closed, but I couldn't figure out a way to do that. 

## Related Issue(s)

Fixes #539 

