### PR TITLE
Input - put cursor right after the default prompt

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -189,7 +189,7 @@ function M.input(opts, on_confirm)
   vim.cmd.startinsert()
   if opts.default then
     vim.api.nvim_buf_set_lines(win.buf, 0, -1, false, { opts.default })
-    vim.api.nvim_win_set_cursor(win.win, { 1, #opts.default + 1 })
+    vim.api.nvim_win_set_cursor(win.win, { 1, #opts.default })
   end
   vim.fn.prompt_setcallback(win.buf, function(text)
     confirm(text)


### PR DESCRIPTION
## Description

When the input opens, the cursor is placed two columns to the right after the default prompt, but should be one.
The cause is the `vim.api.nvim_win_set_cursor` takes (row, col) with the base of (1, 0) */I hate this/*

## Related Issue(s)

No related issue created.

## Screenshots

`:lua Snacks.input({ default = "aaa" }, function () end )`
gives the input as "aaa |" (where pipe shows the cursor position)