### PR TITLE
fix(picker): remove filename from lsp picker text

### DIFF
--- a/lua/snacks/picker/source/lsp.lua
+++ b/lua/snacks/picker/source/lsp.lua
@@ -180,7 +180,7 @@ function M.get_locations(method, opts, filter)
       for _, loc in ipairs(items) do
         ---@type snacks.picker.finder.Item
         local item = {
-          text = loc.filename .. " " .. loc.text,
+          text = loc.text,
           buf = loc.bufnr,
           file = loc.filename,
           pos = { loc.lnum, loc.col },


### PR DESCRIPTION
## Description

Moving lsp pickers to qflist adds an unnecessary absolute path to the entries.
There's more details on discussion https://github.com/folke/snacks.nvim/discussions/536

## Related Issue(s)

No issue, but discussion #536 

