### PR TITLE
fix(bigfile): check existence of NoMatchParen before executing

### DIFF
--- a/lua/snacks/bigfile.lua
+++ b/lua/snacks/bigfile.lua
@@ -15,7 +15,9 @@ local defaults = {
   -- Enable or disable features when big file detected
   ---@param ctx {buf: number, ft:string}
   setup = function(ctx)
-    vim.cmd([[NoMatchParen]])
+    if vim.fn.exists("NoMatchParen") then
+      vim.cmd([[NoMatchParen]])
+    end
     Snacks.util.wo(0, { foldmethod = "manual", statuscolumn = "", conceallevel = 0 })
     vim.b.minianimate_disable = true
     vim.schedule(function()

--- a/lua/snacks/bigfile.lua
+++ b/lua/snacks/bigfile.lua
@@ -15,7 +15,7 @@ local defaults = {
   -- Enable or disable features when big file detected
   ---@param ctx {buf: number, ft:string}
   setup = function(ctx)
-    if vim.fn.exists("NoMatchParen") then
+    if vim.fn.exists(":NoMatchParen") ~= 0 then
       vim.cmd([[NoMatchParen]])
     end
     Snacks.util.wo(0, { foldmethod = "manual", statuscolumn = "", conceallevel = 0 })


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

In my config I use the following flag to disable the default `MatchParen` plugin.

```
vim.g.loaded_matchparen = 1
```

This causes an error when `bigfile` tries to call the `NoMatchParen` command since it does not exist.
This PR fixes that by checking for the existence of the command before executing it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

