### PR TITLE
fix(picker): result line cannot contain new lines

### DIFF
--- a/lua/snacks/picker/core/list.lua
+++ b/lua/snacks/picker/core/list.lua
@@ -388,6 +388,11 @@ end
 ---@param row number
 function M:_render(item, row)
   local text, extmarks = self:format(item)
+  -- unvetted text may contain new lines, this makes nvim_buf_set_lines fail
+  local new_line_idx = string.find(text, "\n")
+  if new_line_idx then
+    text = string.sub(text, 1, new_line_idx - 1)
+  end
   vim.api.nvim_buf_set_lines(self.win.buf, row - 1, row, false, { text })
   for _, extmark in ipairs(extmarks) do
     local col = extmark.col


### PR DESCRIPTION
## Description

if a result item text contains new line character it will raise an error

```
Error executing vim.schedule lua callback: ...nvim/plugged/snacks.nvim/lua/snacks/picker/core/list.lua:391: 'replacement string' item contains newlines
stack traceback:
        [C]: in function 'nvim_buf_set_lines'
        ...nvim/plugged/snacks.nvim/lua/snacks/picker/core/list.lua:391: in function '_render'
        ...nvim/plugged/snacks.nvim/lua/snacks/picker/core/list.lua:434: in function 'render'
        ...nvim/plugged/snacks.nvim/lua/snacks/picker/core/list.lua:271: in function 'update'
        ...im/plugged/snacks.nvim/lua/snacks/picker/core/picker.lua:429: in function 'update'
        ...im/plugged/snacks.nvim/lua/snacks/picker/core/picker.lua:385: in function <...im/plugged/snacks.nvim/lua/snacks/picker/core/picker.lua:384>
```

To avoid this we can either only show the first line (initial proposed solution) or replace new line characters with spaces.

## Repro

```lua
require('lazy').setup({
    {
        'folke/snacks.nvim',
        opts = {
            picker = {},
        },
        keys = {
            {
                '<leader>;',
                function()
                    local items = {}
                    for _, cmd in pairs(vim.api.nvim_get_commands({})) do
                        table.insert(items, cmd)
                    end

                    vim.ui.select(items, {
                        prompt = 'Command picker',
                        format_item = function(entry)
                            local padding = string.rep(' ', math.max(32 - #entry.name, 2))
                            return entry.name .. padding .. (entry.definition or '')
                        end,
                    }, function(pick)
                        if pick then
                            local cmd = ':' .. pick.name .. ' '
                            if pick.nargs == '0' then
                                cmd = cmd
                                    .. vim.api.nvim_replace_termcodes('<cr>', true, false, true)
                            end
                            vim.cmd.stopinsert()
                            vim.api.nvim_feedkeys(cmd, 'nt', false)
                        end
                    end)
                end,
            },
        },
    },
})

vim.api.nvim_create_user_command('FooBar', function() end, {
    desc = [[This is a multiline description
     that can be used to describe the command]],
})
```

press `<leader>;` to trigger command picker

Side note: while it is possible to fix this issue in my custom command picker, I think there can be more cases where this issue can surface itself.

## Related Issue(s)

N/A

## Screenshots

N/A

