### PR TITLE
feat(picker): custom icon for unselected entries 

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -239,6 +239,7 @@ local defaults = {
     ui = {
       live        = "󰐰 ",
       selected    = "● ",
+      unselected = "○ ",
       -- selected = " ",
     },
     git = {

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -389,10 +389,10 @@ end
 
 function M.selected(item, picker)
   local selected = picker.list:is_selected(item)
-  local icon = picker.opts.icons.ui.selected
-  local icon_width = vim.api.nvim_strwidth(icon)
+  local icon_selected = picker.opts.icons.ui.selected
+  local icon_unselected = picker.opts.icons.ui.unselected
   local ret = {} ---@type snacks.picker.Highlight[]
-  ret[#ret + 1] = { selected and icon or string.rep(" ", icon_width), "SnacksPickerSelected", virtual = true }
+  ret[#ret + 1] = { selected and icon_selected or icon_unselected, "SnacksPickerSelected", virtual = true }
   return ret
 end
 


### PR DESCRIPTION
Snacks picker allows setting an icon for selected list entries.
With this PR, we can also select one for unselected entries.

I think it looks great.

![image](https://github.com/user-attachments/assets/00efa0f3-bf48-4a2d-a823-78b540b8adc2)