### PR TITLE
fix(picker): show all files in git status

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -86,6 +86,7 @@ end
 function M.status(opts)
   local args = {
     "status",
+    "-uall",
     "--porcelain=v1",
   }
 


### PR DESCRIPTION
## Description

When new folder is created in a git project, and there are files inside, git status picker only shows the folder without any preview. Adding `-uall` to the commands lists them all.

## Related Issue(s)



## Screenshots

Before: 
![screenshot_2025_01_17_15_42_14](https://github.com/user-attachments/assets/e556f563-dc63-472e-9543-bc784e6e1a35)

After: 
![screenshot_2025_01_17_15_43_13](https://github.com/user-attachments/assets/d6b6d715-02fd-4c77-b167-5c62058153dc)


