### PR TITLE
feat(picker): custom icon for unselected entries

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -239,6 +239,7 @@ local defaults = {
     ui = {
       live        = "󰐰 ",
       selected    = "● ",
+      unselected = "○ ",
       -- selected = " ",
     },
     git = {

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -114,6 +114,10 @@ local defaults = {
     file = {
       filename_first = false, -- display filename before the file path
     },
+    selected = {
+      show_always = false, -- only show the selected column when there are multiple selections
+      unselected = true, -- use the unselected icon for unselected items
+    },
   },
   ---@class snacks.picker.previewers.Config
   previewers = {

--- a/lua/snacks/picker/config/highlights.lua
+++ b/lua/snacks/picker/config/highlights.lua
@@ -18,6 +18,7 @@ Snacks.util.set_hl({
   Delim = "Delimiter",
   Spinner = "Special",
   Selected = "Number",
+  Unselected = "NonText",
   Idx = "Number",
   Bold = "Bold",
   Indent = "LineNr",

--- a/lua/snacks/picker/core/list.lua
+++ b/lua/snacks/picker/core/list.lua
@@ -333,7 +333,11 @@ end
 function M:format(item)
   -- Add selected and debug info
   local prefix = {} ---@type snacks.picker.Highlight[]
-  vim.list_extend(prefix, Snacks.picker.format.selected(item, self.picker))
+  if #self.selected > 0 or self.picker.opts.formatters.selected.show_always then
+    vim.list_extend(prefix, Snacks.picker.format.selected(item, self.picker))
+  else
+    prefix[#prefix + 1] = { " " }
+  end
   if self.picker.opts.debug.scores then
     vim.list_extend(prefix, Snacks.picker.format.debug(item, self.picker))
   end

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -388,11 +388,18 @@ function M.buffer(item, picker)
 end
 
 function M.selected(item, picker)
-  local selected = picker.list:is_selected(item)
-  local icon_selected = picker.opts.icons.ui.selected
-  local icon_unselected = picker.opts.icons.ui.unselected
+  local a = Snacks.picker.util.align
+  local selected = picker.opts.icons.ui.selected
+  local unselected = picker.opts.icons.ui.unselected
+  local width = math.max(vim.api.nvim_strwidth(selected), vim.api.nvim_strwidth(unselected))
   local ret = {} ---@type snacks.picker.Highlight[]
-  ret[#ret + 1] = { selected and icon_selected or icon_unselected, "SnacksPickerSelected", virtual = true }
+  if picker.list:is_selected(item) then
+    ret[#ret + 1] = { a(selected, width), "SnacksPickerSelected", virtual = true }
+  elseif picker.opts.formatters.selected.unselected then
+    ret[#ret + 1] = { a(unselected, width), "SnacksPickerUnselected", virtual = true }
+  else
+    ret[#ret + 1] = { a("", width) }
+  end
   return ret
 end
 

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -389,10 +389,10 @@ end
 
 function M.selected(item, picker)
   local selected = picker.list:is_selected(item)
-  local icon = picker.opts.icons.ui.selected
-  local icon_width = vim.api.nvim_strwidth(icon)
+  local icon_selected = picker.opts.icons.ui.selected
+  local icon_unselected = picker.opts.icons.ui.unselected
   local ret = {} ---@type snacks.picker.Highlight[]
-  ret[#ret + 1] = { selected and icon or string.rep(" ", icon_width), "SnacksPickerSelected", virtual = true }
+  ret[#ret + 1] = { selected and icon_selected or icon_unselected, "SnacksPickerSelected", virtual = true }
   return ret
 end
 


### PR DESCRIPTION
Snacks picker allows setting an icon for selected list entries.
With this PR, we can also select one for unselected entries.

I think it looks great.

![image](https://github.com/user-attachments/assets/f97543ae-b0ab-4490-9fd5-f8d8f1b804a9)

(Replica of #583 which I closed by mistake, sorry about that.)