### PR TITLE
fix(picker): format: one too many spaces for default icon in results …

### DIFF
--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -37,7 +37,8 @@ function M.filename(item, picker)
 
   if picker.opts.icons.files.enabled ~= false then
     local icon, hl = Snacks.util.icon(name, cat)
-    ret[#ret + 1] = { icon .. " ", hl, virtual = true }
+    local padded_icon = icon:sub(-1) == " " and icon or icon .. " "
+    ret[#ret + 1] = { padded_icon, hl, virtual = true }
   end
 
   local dir, file = path:match("^(.*)/(.+)$")


### PR DESCRIPTION
The default icon returned from Snacks utils already has a space for padding.

The fix is to only append a space if there's none.

![image](https://github.com/user-attachments/assets/547ee166-ef4c-48b9-ad14-01563c630bc8)