### PR TITLE
feat(picker): add qflist_all action to send all even when already sel…

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -167,6 +167,12 @@ function M.qflist(picker)
   setqflist(items)
 end
 
+--- Send all items to the quickfix list.
+function M.qflist_all(picker)
+  picker:close()
+  setqflist(picker:items())
+end
+
 --- Send selected or all items to the location list.
 function M.loclist(picker)
   picker:close()


### PR DESCRIPTION
Adds a new action `qflist_all` that send all items to quickfix even when there are already selected ones. This complements the "selected or all" behaviour of `qflist`.
