### PR TITLE
fix(picker): add OS-specific path separator support

### DIFF
--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -41,14 +41,15 @@ function M.filename(item, picker)
     ret[#ret + 1] = { padded_icon, hl, virtual = true }
   end
 
-  local dir, file = path:match("^(.*)/(.+)$")
+  local path_separator = vim.uv.os_uname().sysname:find("Windows") and "\\" or "/"
+  local dir, file = path:match("^(.*)" .. path_separator .. "(.+)$")
   if file and dir then
     if picker.opts.formatters.file.filename_first then
       ret[#ret + 1] = { file, "SnacksPickerFile", field = "file" }
       ret[#ret + 1] = { " " }
       ret[#ret + 1] = { dir, "SnacksPickerDir", field = "file" }
     else
-      ret[#ret + 1] = { dir .. "/", "SnacksPickerDir", field = "file" }
+      ret[#ret + 1] = { dir .. path_separator, "SnacksPickerDir", field = "file" }
       ret[#ret + 1] = { file, "SnacksPickerFile", field = "file" }
     end
   else


### PR DESCRIPTION
## Description

This update ensures proper syntax highlighting for path entries on Windows systems and correctly applies the `filename_first` formatting option. The changes dynamically detect the appropriate path separator based on the operating system.

## Screenshots

### Before Changes  
**`filename_first = false` or `filename_first = true`:**  
![Before changes](https://github.com/user-attachments/assets/9cef55e7-d9f5-42d8-b1ee-7602f3cc57d0)

### After Changes  
**`filename_first = false`:**  
![After filename_first = false](https://github.com/user-attachments/assets/34026de2-f4be-49e5-9273-d6358fae46f9)  

**`filename_first = true`:**  
![After filename_first = true](https://github.com/user-attachments/assets/25e6c5d1-ea67-4c1c-8a96-97e2fd9eb79c)
