### PR TITLE
fix(notifier): stop flickering when blocked. Fixes #613

### DIFF
--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -401,7 +401,7 @@ function N:add(opts)
   if opts.history ~= false then
     self.history[notif.id] = notif
   end
-  if not self:is_blocking() then
+  if self:is_blocking() then
     pcall(function()
       self:process()
     end)

--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -315,10 +315,12 @@ function N:init()
 end
 
 function N:start()
-  uv.new_timer():start(
-    self.opts.refresh,
-    self.opts.refresh,
-    vim.schedule_wrap(function()
+  uv.new_timer():start(self.opts.refresh, self.opts.refresh, function()
+    if self:is_blocking() then
+      return
+    end
+
+    vim.schedule(function()
       if not next(self.queue) then
         return
       end
@@ -337,7 +339,7 @@ function N:start()
         self.queue = {}
       end)
     end)
-  )
+  end)
 end
 
 function N:process()
@@ -399,7 +401,7 @@ function N:add(opts)
   if opts.history ~= false then
     self.history[notif.id] = notif
   end
-  if self:is_blocking() then
+  if not self:is_blocking() then
     pcall(function()
       self:process()
     end)


### PR DESCRIPTION
## Description

The constant calls to `schedule`, even when the UI is blocked due to the current mode was causing the flickering I was seeing.

## Related Issue(s)

- Fixes #613

## Screenshots

![Image](https://github.com/user-attachments/assets/e63360c3-3f68-494b-a8dd-1e3bbc9c012b)
