### PR TITLE
fix(statusline): fix status line cache key

### DIFF
--- a/lua/snacks/statuscolumn.lua
+++ b/lua/snacks/statuscolumn.lua
@@ -237,7 +237,7 @@ end
 function M.get()
   local win = vim.g.statusline_winid
   local buf = vim.api.nvim_win_get_buf(win)
-  local key = ("%d:%d:%d:%d"):format(win, buf, vim.v.lnum, vim.v.virtnum and 1 or 0)
+  local key = ("%d:%d:%d:%d"):format(win, buf, vim.v.lnum, vim.v.virtnum ~= 0 and 1 or 0)
   if cache[key] then
     return cache[key]
   end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
- https://github.com/folke/snacks.nvim/commit/d972bc0a471fbf3067a115924a4add852d15f5f0 breaks cache key for virtual lines since `0 and 1 or 0` also evaluates to 1 in lua.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #510 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

