### PR TITLE
feat(picker.smart): add bufdelete actions from buffers picker

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -118,10 +118,20 @@ function M.toggle_preview(picker)
 end
 
 function M.bufdelete(picker)
+  local non_buf_delete_requested = false
   for _, item in ipairs(picker:selected({ fallback = true })) do
-    Snacks.bufdelete.delete(item.buf)
+    if item.buf then
+      Snacks.bufdelete.delete(item.buf)
+    else
+      non_buf_delete_requested = true
+    end
     picker.list:unselect(item)
   end
+
+  if non_buf_delete_requested then
+    Snacks.notify.warn("Only open buffers can be deleted", { title = "Snacks Picker" })
+  end
+
   local cursor = picker.list.cursor
   picker:find({
     on_done = function()

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -564,6 +564,15 @@ M.smart = {
   format = "file",
   -- sort the results even when the filter is empty (frecency)
   matcher = { sort_empty = true },
+  win = {
+    input = {
+      keys = {
+        ["dd"] = "bufdelete",
+        ["<c-x>"] = { "bufdelete", mode = { "n", "i" } },
+      },
+    },
+    list = { keys = { ["dd"] = "bufdelete" } },
+  },
 }
 
 M.spelling = {


### PR DESCRIPTION
## Description

This enables the ability to delete buffers directly from the `smart` picker (or other combined pickers) by adding a check + warning to the `bufdelete` action (ensuring it only operates on buffer items), and adding the same `dd` and `<c-x>` mappings as the `buffers` picker.

## Related Issue(s)

TBD... searching.

## Screenshots

https://github.com/user-attachments/assets/6c5c4b5e-74ed-4778-9f31-a714f7da1853


