### PR TITLE
feat(picker): preview window horizontal scrolling

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -311,6 +311,14 @@ function M.preview_scroll_up(picker)
   picker.preview.win:scroll(true)
 end
 
+function M.preview_scroll_left(picker)
+  picker.preview.win:hscroll(true)
+end
+
+function M.preview_scroll_right(picker)
+  picker.preview.win:hscroll()
+end
+
 function M.inspect(picker, item)
   Snacks.debug.inspect(item)
 end

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -177,6 +177,8 @@ local defaults = {
         ["<c-k>"] = { "list_up", mode = { "i", "n" } },
         ["<c-n>"] = { "list_down", mode = { "i", "n" } },
         ["<c-p>"] = { "list_up", mode = { "i", "n" } },
+        ["<c-l>"] = { "preview_scroll_left", mode = { "i", "n" } },
+        ["<c-h>"] = { "preview_scroll_right", mode = { "i", "n" } },
         ["<c-b>"] = { "preview_scroll_up", mode = { "i", "n" } },
         ["<c-d>"] = { "list_scroll_down", mode = { "i", "n" } },
         ["<c-f>"] = { "preview_scroll_down", mode = { "i", "n" } },
@@ -221,6 +223,9 @@ local defaults = {
         ["<c-a>"] = "select_all",
         ["<c-f>"] = "preview_scroll_down",
         ["<c-b>"] = "preview_scroll_up",
+        ["<c-l>"] = "preview_scroll_right",
+        ["<c-h>"] = "preview_scroll_left",
+
         ["<c-v>"] = "edit_vsplit",
         ["<c-s>"] = "edit_split",
         ["<c-j>"] = "list_down",

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -225,7 +225,6 @@ local defaults = {
         ["<c-b>"] = "preview_scroll_up",
         ["<c-l>"] = "preview_scroll_right",
         ["<c-h>"] = "preview_scroll_left",
-
         ["<c-v>"] = "edit_vsplit",
         ["<c-s>"] = "edit_split",
         ["<c-j>"] = "list_down",

--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -479,6 +479,13 @@ function M:redraw()
   end
 end
 
+---@param left? boolean
+function M:hscroll(left)
+  vim.api.nvim_win_call(self.win, function()
+    vim.cmd(("normal! %s"):format(left and "zh" or "zl"))
+  end)
+end
+
 ---@param up? boolean
 function M:scroll(up)
   vim.api.nvim_win_call(self.win, function()


### PR DESCRIPTION
## Description

This is an initial commit for trying to add horizontal scrolling for the picker preview window.

Known issue: when scrolling horizontally with scope indent, the indent chars persist in the preview window and  don't disappear as they should...

Edit:
I just realized this happens only when we are previewing a buffer that is already open. Only in that case the indents are being rendered... if we are previewing a file that is not currently open the indents don't get rendered and therefore there is no issue. Maybe this is a bug? Should we prevent rendering of the indent guides in the preview window? 

## Related Issue(s)

  - Fixes #676 

## Screenshots

![image](https://github.com/user-attachments/assets/573fdba6-93cf-44f1-824d-609106996e6b)



