### PR TITLE
feat(picker): add symbols source

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -303,6 +303,14 @@ function M.help(picker)
   end
 end
 
+function M.insert_symbol(picker)
+  local item = picker:current()
+  if item then
+    picker:close()
+    vim.api.nvim_put({ item.symbol }, "", true, true)
+  end
+end
+
 function M.preview_scroll_down(picker)
   picker.preview.win:scroll()
 end

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -582,6 +582,14 @@ M.spelling = {
   confirm = "item_action",
 }
 
+M.symbols = {
+  finder = "symbols",
+  format = "symbol",
+  preview = "none",
+  layout = { preset = "vscode" },
+  confirm = "insert_symbol",
+}
+
 M.undo = {
   finder = "vim_undo",
   format = "undo",

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -493,4 +493,12 @@ function M.debug(item, picker)
   return ret
 end
 
+function M.symbol(item, picker)
+  local ret = {} ---@type snacks.picker.Highlight[]
+  ret[#ret + 1] = { Snacks.picker.util.align(item.symbol, 4) }
+  ret[#ret + 1] = { " " }
+  ret[#ret + 1] = { item.desc }
+  return ret
+end
+
 return M

--- a/lua/snacks/picker/source/symbols.lua
+++ b/lua/snacks/picker/source/symbols.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+---@class snacks.picker
+---@field symbols fun(opts?: snacks.picker.symbols.Config): snacks.Picker
+
+---@class snacks.picker.symbols.Config
+---@field data string[]
+
+---@param opts snacks.picker.symbols.Config
+function M.symbols(opts)
+  ---@async
+  ---@param cb async fun(item: snacks.picker.finder.Item)
+  return function(cb)
+    ---@type string[]
+    local files = vim.tbl_filter(function(file)
+      return vim.tbl_contains(opts.data, vim.fn.fnamemodify(file, ":t:r"))
+    end, vim.api.nvim_get_runtime_file("data/telescope-sources/*.json", true))
+
+    for _, file in ipairs(files) do
+      local fd = vim.uv.fs_open(file, "r", 438)
+      if not fd then
+        goto continue
+      end
+      local stat = assert(vim.uv.fs_fstat(fd))
+      local data = assert(vim.uv.fs_read(fd, stat.size, 0))
+      local items = vim.json.decode(data)
+      for _, item in ipairs(items) do
+        cb({
+          text = item[1] .. " " .. item[2],
+          symbol = item[1],
+          desc = item[2],
+        })
+      end
+      vim.uv.fs_close(fd)
+
+      ::continue::
+    end
+  end
+end
+
+return M


### PR DESCRIPTION
## Description

This PR adds the symbols picker that was in telescope.nvim.

The data source for the symbols is not included in this PR, and the data source included in telescope-symbols.nvim can be used without modification.

For example:

```lua
{
  "folke/snacks.nvim",
  dependencies = { "nvim-telescope/telescope-symbols.nvim" },
  keys = {
    { "<leader>iu", function() Snacks.picker.symbols({ data = { "unicode" } }) } end },
    { "<leader>ie", function() Snacks.picker.symbols({ data = { "emoji" } }) } end },
    { "<leader>im", function() Snacks.picker.symbols({ data = { "math" } }) } end },
    { "<leader>ig", function() Snacks.picker.symbols({ data = { "gitmoji" } }) } end, ft = "gitcommit" },
    { "<leader>ij", function() Snacks.picker.symbols({ data = { "julia" } }) } end, ft = "julia" },
  },
}
```

- TODO: write doc
- TODO: add screenshots

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

