### PR TITLE
feat(picker.keymaps): add global + buffer toggles

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -293,6 +293,24 @@ M.keymaps = {
       vim.api.nvim_input(item.item.lhs)
     end
   end,
+  actions = {
+    toggle_global = function(picker)
+      picker.opts.global = not picker.opts.global
+      picker:find()
+    end,
+    toggle_buffer = function(picker)
+      picker.opts["local"] = not picker.opts["local"]
+      picker:find()
+    end,
+  },
+  win = {
+    input = {
+      keys = {
+        ["<a-g>"] = { "toggle_global", mode = { "n", "i" }, desc = "Toggle Global Keymaps" },
+        ["<a-b>"] = { "toggle_buffer", mode = { "n", "i" }, desc = "Toggle Buffer Keymaps" },
+      },
+    },
+  },
 }
 
 -- Search lines in the current buffer


### PR DESCRIPTION
## Description

This PR adds 2 actions to the `keymaps` picker, to toggle the `global` and `local` options.

## Related Issue(s)

None.

## Screenshots

https://github.com/user-attachments/assets/3f4ca80a-b554-47a2-970b-15dc84f357d8

