### PR TITLE
fix(picker.icons): fix typo in Nerd Fonts and display the full category name

### DIFF
--- a/lua/snacks/picker/source/icons.lua
+++ b/lua/snacks/picker/source/icons.lua
@@ -1,5 +1,21 @@
 local M = {}
 
+local NERDFONTS_SETS = {
+  cod = "Codicons",
+  dev = "Devicons",
+  fa = "Font Awesome",
+  fae = "Font Awesome Extension",
+  iec = "IEC Power Symbols",
+  linux = "Font Logos",
+  logos = "Font Logos",
+  oct = "Octicons",
+  ple = "Powerline Extra",
+  pom = "Pomicons",
+  seti = "Seti-UI",
+  weather = "Weather Icons",
+  md = "Material Design Icons",
+}
+
 ---@type table<string, {url: string, v?:number, build: fun(data:table):snacks.picker.Icon[]}>
 M.sources = {
   nerd_fonts = {
@@ -17,8 +33,8 @@ M.sources = {
           table.insert(ret, {
             name = icon,
             icon = info.char,
-            source = "nerd font",
-            category = font,
+            source = "nerd fonts",
+            category = NERDFONTS_SETS[font] or font,
           })
         end
       end


### PR DESCRIPTION
## Description

Thanks for the icons picker 🙇🏼 

I had one in my dotfiles I was going to contribute, but you have been faster.
So there it is, I added some things I had in mine

This PR:
- fix a typo in the Nerd Fonts source name (its plural)
- add The category full names to be consistent with emojis
 
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
![image](https://github.com/user-attachments/assets/0691b3ac-665a-4d53-92ad-aa3cc56d1546)

<!-- Add screenshots of the changes if applicable. -->

> [!NOTE]
> Would you be interested in some extra sources I was working on ? At least Math and Box drawing ?

> [!NOTE]
> I would also switch the name the source so Source can be capitalize like the Category and I think having Source > Category after is easier to read as the glyph and the icons are actuelly what people search. But this is personal taste, sp I did not submnitted this change
