### PR TITLE
feat(picker.format): add `auto` and `align` options for path truncate

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -133,7 +133,12 @@ local defaults = {
     },
     file = {
       filename_first = false, -- display filename before the file path
-      truncate = 40, -- truncate the file path to (roughly) this length
+      --- Truncate types:
+      --- * number: truncate the file path to (roughly) this length
+      --- * auto: similar to number, but based on the window width
+      --- * align: align filename to the right border of the window
+      ---@type number|"auto"|"align"|fun(item:snacks.picker.Item, picker:snacks.Picker):string
+      truncate = 40,
       filename_only = false, -- only show the filename
     },
     selected = {

--- a/lua/snacks/picker/util/init.lua
+++ b/lua/snacks/picker/util/init.lua
@@ -15,8 +15,8 @@ function M.path(item)
 end
 
 ---@param path string
----@param len? number
----@param opts? {cwd?: string}
+---@param len number
+---@param opts? {cwd?: string, roughly?: boolean}
 function M.truncpath(path, len, opts)
   local cwd = vim.fs.normalize(opts and opts.cwd or vim.fn.getcwd(), { _fast = true, expand_env = false })
   local home = vim.fs.normalize("~")
@@ -32,6 +32,10 @@ function M.truncpath(path, len, opts)
     elseif path:find(home, 1, true) == 1 then
       path = "~" .. path:sub(#home + 1)
     end
+  end
+
+  if opts and opts.roughly == false then
+    return M.truncate(path, len, -1)
   end
 
   if vim.api.nvim_strwidth(path) <= len then
@@ -134,9 +138,12 @@ end
 
 ---@param text string
 ---@param width number
-function M.truncate(text, width)
-  if vim.api.nvim_strwidth(text) > width then
-    return vim.fn.strcharpart(text, 0, width - 1) .. "…"
+---@param direction? -1 | 1
+function M.truncate(text, width, direction)
+  local tw = vim.api.nvim_strwidth(text)
+  if tw > width then
+    return direction == -1 and "…" .. vim.fn.strcharpart(text, tw - width + 1, width - 1)
+      or vim.fn.strcharpart(text, 0, width - 1) .. "…"
   end
   return text
 end


### PR DESCRIPTION
## Description

- To prevent wasting width of snacks_picker_list, add the `auto` option to `formatters.file.truncate`.
- To make it more intuitive whether truncate or not, add the `align` option to `formatters.file.truncate`.
- Allow `formatters.file.truncate` to be a function to customize.

## Related Issue(s)

- Work on [#708](https://github.com/folke/snacks.nvim/issues/708).

## Screenshots

auto:

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/6a187b60-80bb-4c0a-ac93-4a117447d42c" />

align:

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/fffe3502-b30a-4723-929a-aea29f1c2c0f" />