### PR TITLE
feat(win): use which-key for toggle_help when available

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -353,6 +353,12 @@ end
 
 ---@param opts? {col_width?: number, key_width?: number, win?: snacks.win.Config}
 function M:toggle_help(opts)
+  --- if which-key is available, use it
+  if package.loaded["which-key"] then
+    require("which-key").show({ global = false, delay = 0, defer = false })
+    return
+  end
+
   opts = opts or {}
   local col_width, key_width = opts.col_width or 30, opts.key_width or 10
   for _, win in ipairs(vim.api.nvim_list_wins()) do
@@ -362,6 +368,7 @@ function M:toggle_help(opts)
       return
     end
   end
+
   local ns = vim.api.nvim_create_namespace("snacks.win.help")
   local win = M.new(M.resolve({ style = "help" }, opts.win or {}, {
     show = false,


### PR DESCRIPTION
## Description

Leverage `which-key` to show the help window when available.

## Related Issue(s)

N/A

## Screenshots


https://github.com/user-attachments/assets/722048ea-c882-4c0a-b7db-512b136db770

https://github.com/user-attachments/assets/e65f7657-bc83-4de0-9bdd-d9f3dce6c5d9


