### PR TITLE
feat(picker): add support for staged changes in git_diff

### DIFF
--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -299,6 +299,10 @@ function M.git_diff(ctx)
     "--",
     ctx.item.file,
   }
+  local staged = ctx.item.text:match("^M%s+")
+  if staged then
+    table.insert(cmd, 5, "--staged")
+  end
   if not native then
     table.insert(cmd, 2, "--no-pager")
   end

--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -296,13 +296,10 @@ function M.git_diff(ctx)
     "-c",
     "delta." .. vim.o.background .. "=true",
     "diff",
+    "HEAD",
     "--",
     ctx.item.file,
   }
-  local staged = ctx.item.text:match("^M%s+")
-  if staged then
-    table.insert(cmd, 5, "--staged")
-  end
   if not native then
     table.insert(cmd, 2, "--no-pager")
   end


### PR DESCRIPTION
Fixes #747

- This update introduces the ability to handle staged changes in the git_diff function.
- By explicitly using `HEAD`, `git diff` will show changes both staged and not staged

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

