### PR TITLE
fix(bufdelete): ctrl-c throw error in `fn.confirm`

### DIFF
--- a/lua/snacks/bufdelete.lua
+++ b/lua/snacks/bufdelete.lua
@@ -41,8 +41,8 @@ function M.delete(opts)
 
   vim.api.nvim_buf_call(buf, function()
     if vim.bo.modified and not opts.force then
-      local choice = vim.fn.confirm(("Save changes to %q?"):format(vim.fn.bufname()), "&Yes\n&No\n&Cancel")
-      if choice == 0 or choice == 3 then -- 0 for <Esc>/<C-c> and 3 for Cancel
+      local ok, choice = pcall(vim.fn.confirm, (("Save changes to %q?"):format(vim.fn.bufname()), "&Yes\n&No\n&Cancel"))
+      if not ok or choice == 0 or choice == 3 then -- 0 for <Esc>/<C-c> and 3 for Cancel
         return
       end
       if choice == 1 then -- Yes


### PR DESCRIPTION
`vim.fn.confirm` don't return 3 on ctrl-c, but throw an error.
```
E5108: Error executing lua Keyboard interrupt
```
