### PR TITLE
feat(gitbrowse): add azure to url patterns

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -62,6 +62,11 @@ local defaults = {
       file = "/src/{branch}/{file}#lines-{line_start}-L{line_end}",
       commit = "/commits/{commit}",
     },
+    ["dev%.azure%.com"] = {
+      file = "?path=/{file}&version=GB{branch}&line={line_start}&lineEnd={line_end}&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents",
+      commit = "/commit/{commit}",
+      branch = "",
+    },
   },
 }
 


### PR DESCRIPTION
## Description
When copying git lines for Azure repo, i was getting just a root repo link without any reference to lines, so this pr adds Azure url pattern.

