### PR TITLE
fix(filter): correctly use `uv.cwd` when `opts.cwd=true`

### DIFF
--- a/lua/snacks/picker/core/filter.lua
+++ b/lua/snacks/picker/core/filter.lua
@@ -33,7 +33,7 @@ function M.new(picker)
   self.all = not filter or not (filter.cwd or filter.buf or filter.paths or filter.filter)
   self.paths = {}
   local cwd = filter and filter.cwd
-  self.cwd = type(cwd) == "string" and cwd or opts.cwd or uv.cwd() or "."
+  self.cwd = type(cwd) == "string" and cwd or opts.cwd and uv.cwd() or "."
   self.cwd = vim.fs.normalize(self.cwd --[[@as string]], { _fast = true })
   if not self.all and filter then
     self.buf = filter.buf == true and 0 or filter.buf --[[@as number?]]


### PR DESCRIPTION
## Description
When `opts.cwd=true` the value of `uv.cwd` should be used to set `self.cwd`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #754 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

