### PR TITLE
fix(filter): insert path from `filter.paths` into `self.paths`

### DIFF
--- a/lua/snacks/picker/core/filter.lua
+++ b/lua/snacks/picker/core/filter.lua
@@ -40,7 +40,7 @@ function M.new(picker)
     self.buf = self.buf == 0 and vim.api.nvim_get_current_buf() or self.buf
     self.file = self.buf and vim.fs.normalize(vim.api.nvim_buf_get_name(self.buf), { _fast = true }) or nil
     for path, want in pairs(filter.paths or {}) do
-      table.insert(filter, { path = vim.fs.normalize(path), want = want })
+      table.insert(self.paths, { path = vim.fs.normalize(path), want = want })
     end
   end
   return self


### PR DESCRIPTION
## Description
Here we see that we insert the paths into `filter` instead of `self.paths` https://github.com/folke/snacks.nvim/blob/b96bd540f785c725289f9f15f0147b1b2dac5a35/lua/snacks/picker/core/filter.lua#L34-L44
 and later on here https://github.com/folke/snacks.nvim/blob/b96bd540f785c725289f9f15f0147b1b2dac5a35/lua/snacks/picker/core/filter.lua#L90-L94 we check `self.paths` to get the path.

This was causing issues to not correctly filter out the already defined paths and I was able to see, for example the scratch buffer files in the pickers.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

