### PR TITLE
fix(picker.resume): fix picker is nil

### DIFF
--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -338,6 +338,9 @@ function M.resume()
   ret.matcher.task:on(
     "done",
     vim.schedule_wrap(function()
+      if ret.closed then
+        return
+      end
       ret.list:view(last.cursor, last.topline)
     end)
   )


### PR DESCRIPTION
## Description
 `Picker.resume` sometimes get an error:
```
Error executing vim.schedule lua callback: ...zy_178550383/snacks.nvim/lua/snacks/picker/core/list.lua:183: attempt to index field 'picker' (a nil value)
stack traceback:
        ...zy_178550383/snacks.nvim/lua/snacks/picker/core/list.lua:183: in function '_move'
        ...zy_178550383/snacks.nvim/lua/snacks/picker/core/list.lua:203: in function 'move'
        ...zy_178550383/snacks.nvim/lua/snacks/picker/core/list.lua:100: in function 'view'
        ..._178550383/snacks.nvim/lua/snacks/picker/core/picker.lua:341: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```
## Steps to reproduce
1. `Snacks.picker.grep({live=false, search='a'})`.   ##  run in a big repro
2. close picker immediately before `rg` stops running
3. run `resume`
4.  close picker and get an error



