### PR TITLE
fix(dashboard): don't override user configuration

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -768,7 +768,7 @@ function M.pick(cmd, opts)
     function() return Snacks.picker(cmd, opts) end,
   }
   if picker.enabled then
-    table.insert(try, 1, table.remove(try, #try))
+    table.insert(try, 2, table.remove(try, #try))
   end
   for _, fn in ipairs(try) do
     if pcall(fn) then


### PR DESCRIPTION
## Description

When `picker` is enabled, the original line removes it from the table and reinserts it as the first element, preventing the user configuration in `preset.picker` from being used as the picker. This change inserts it as the second element instead.