### PR TITLE
fix(win): error when enabling padding with `listchars=""`

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -895,7 +895,7 @@ end
 function M:add_padding()
   local listchars = vim.split(self.opts.wo.listchars or "", ",")
   listchars = vim.tbl_filter(function(s)
-    return not s:find("eol:")
+    return not s:find("eol:") and s ~= ""
   end, listchars)
   table.insert(listchars, "eol: ")
   self.opts.wo.listchars = table.concat(listchars, ",")


### PR DESCRIPTION
## Description

`vim.split` would split `""` into `{ "" }`, causing `table.concat` to output `",eol: "`.

Resolved by using `vim.tbl_filter` to filter out empty strings before applying `table.concat`.

