### PR TITLE
feat(picker): new file explorer `Snacks.picker.explorer()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@
 /debug
 /doc/tags
 foo.*
+foo*.*
 node_modules
 tt.*
+/tmp
+repomix*
+.aider*

--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -132,7 +132,9 @@ function M.new(opts)
     local sp = vim.fn.screenpos(self.root.win, 1, 1)
     if not vim.deep_equal(sp, self.screenpos) then
       self.screenpos = sp
-      self:update()
+      return self:update()
+    elseif vim.tbl_contains(vim.v.event.windows, self.root.win) then
+      return self:update()
     end
   end)
 
@@ -376,6 +378,15 @@ end
 ---@param parent snacks.win.Dim
 ---@private
 function M:dim_box(widget, parent)
+  -- honor the actual window size for split layouts
+  if not self.opts.fullscreen and widget.id == 1 and self.split and self.root:valid() then
+    return {
+      height = vim.api.nvim_win_get_height(self.root.win),
+      width = vim.api.nvim_win_get_width(self.root.win),
+      col = 0,
+      row = 0,
+    }, { left = 0, right = 0, top = 0, bottom = 0 }
+  end
   local opts = vim.deepcopy(widget) --[[@as snacks.win.Config]]
   -- adjust max width / height
   opts.max_width = math.min(parent.width, opts.max_width or parent.width)

--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -52,10 +52,12 @@ function M.new(opts)
   if self.opts.layout.position and self.opts.layout.position ~= "float" then
     local inner = self.opts.layout
     self.opts.layout = {
+      zindex = inner.zindex or 30,
       box = "vertical",
       position = inner.position,
       width = inner.width,
       height = inner.height,
+      backdrop = inner.backdrop,
       inner,
     }
     inner.width, inner.height, inner.col, inner.row, inner.position = 0, 0, 0, 0, nil
@@ -71,9 +73,18 @@ function M.new(opts)
       local has_border = box.border and box.border ~= "" and box.border ~= "none"
       local is_root = box.id == 1
       if is_root or has_border then
-        local backdrop = false ---@type boolean?
-        if is_root then
-          backdrop = nil
+        local backdrop = box.backdrop
+        if backdrop == nil then
+          backdrop = 60
+        end
+        if is_root and backdrop then
+          backdrop = type(backdrop) == "number" and { blend = backdrop } or backdrop
+          backdrop = backdrop == true and {} or backdrop
+          ---@cast backdrop snacks.win.Backdrop
+          backdrop.win = backdrop.win or {}
+          backdrop.win.zindex = 20
+        else
+          backdrop = false
         end
         self.box_wins[box.id] = Snacks.win(Snacks.win.resolve(box, {
           relative = is_root and (box.relative or "editor") or "win",

--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -5,6 +5,7 @@
 ---@field box_wins snacks.win[]
 ---@field win_opts table<string, snacks.win.Config>
 ---@field closed? boolean
+---@field screenpos number[]?
 local M = {}
 M.__index = M
 
@@ -111,6 +112,17 @@ function M.new(opts)
     end
   end)
 
+  self.root:on("WinResized", function(_, ev)
+    if self.closed then
+      return true
+    end
+    local sp = vim.fn.screenpos(self.root.win, 1, 1)
+    if not vim.deep_equal(sp, self.screenpos) then
+      self.screenpos = sp
+      self:update()
+    end
+  end)
+
   -- update layout on VimResized
   self.root:on("VimResized", function()
     self:update()
@@ -183,6 +195,7 @@ function M:update()
   end
   if not self.root:valid() then
     self.root:show()
+    self.screenpos = vim.fn.screenpos(self.root.win, 1, 1)
   end
 
   -- Calculate offsets for vertical splits

--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -104,9 +104,21 @@ end
 M.cancel = "close"
 M.edit = M.jump
 M.confirm = M.jump
-M.edit_split = { action = "jump", cmd = "split" }
-M.edit_vsplit = { action = "jump", cmd = "vsplit" }
-M.edit_tab = { action = "jump", cmd = "tabnew" }
+M.edit_split = { "split", "confirm" }
+M.edit_vsplit = { "vsplit", "confirm" }
+M.edit_tab = { "tab", "confirm" }
+
+function M.split()
+  vim.cmd("split")
+end
+
+function M.vsplit()
+  vim.cmd("vsplit")
+end
+
+function M.tab()
+  vim.cmd("tabnew")
+end
 
 function M.toggle_maximize(picker)
   picker.layout:maximize()
@@ -361,6 +373,7 @@ function M.load_session(picker)
 end
 
 function M.help(picker)
+  dd("help")
   local item = picker:current()
   if item then
     picker:close()
@@ -453,6 +466,7 @@ end
 function M.toggle_hidden(picker)
   local opts = picker.opts --[[@as snacks.picker.files.Config]]
   opts.hidden = not opts.hidden
+  picker.list:set_target()
   picker:find()
 end
 

--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -448,12 +448,6 @@ function M.focus_preview(picker)
   picker.preview.win:focus()
 end
 
-function M.toggle_ignored(picker)
-  local opts = picker.opts --[[@as snacks.picker.files.Config]]
-  opts.ignored = not opts.ignored
-  picker:find()
-end
-
 function M.item_action(picker, item, action)
   if item.action then
     picker:norm(function()
@@ -461,19 +455,6 @@ function M.item_action(picker, item, action)
       item.action(picker, item, action)
     end)
   end
-end
-
-function M.toggle_hidden(picker)
-  local opts = picker.opts --[[@as snacks.picker.files.Config]]
-  opts.hidden = not opts.hidden
-  picker.list:set_target()
-  picker:find()
-end
-
-function M.toggle_follow(picker)
-  local opts = picker.opts --[[@as snacks.picker.files.Config]]
-  opts.follow = not opts.follow
-  picker:find()
 end
 
 function M.list_top(picker)

--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -421,14 +421,10 @@ function M.cycle_win(picker)
   end
   win = wins[idx % #wins + 1] or 1 -- cycle
   vim.api.nvim_set_current_win(win)
-  if win == picker.input.win.win then
-    vim.cmd("startinsert!")
-  end
 end
 
 function M.focus_input(picker)
   picker.input.win:focus()
-  vim.cmd("startinsert!")
 end
 
 function M.focus_list(picker)

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -83,6 +83,7 @@ local M = {}
 ---@field prompt? string prompt text / icon
 ---@field title? string defaults to a capitalized source name
 ---@field auto_close? boolean automatically close the picker when focusing another window (defaults to true)
+---@field focus? "input"|"list"|false where to focus when the picker is opened (defaults to "input")
 --- Preset options
 ---@field previewers? snacks.picker.previewers.Config|{}
 ---@field formatters? snacks.picker.formatters.Config|{}
@@ -101,6 +102,7 @@ local M = {}
 local defaults = {
   prompt = " ",
   sources = {},
+  focus = "input",
   layout = {
     cycle = true,
     --- Use the default layout or vertical if the window is too narrow

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -8,6 +8,7 @@ local M = {}
 ---@alias snacks.picker.sort fun(a:snacks.picker.Item, b:snacks.picker.Item):boolean
 ---@alias snacks.picker.transform fun(item:snacks.picker.finder.Item, ctx:snacks.picker.finder.ctx):(boolean|snacks.picker.finder.Item|nil)
 ---@alias snacks.picker.Pos {[1]:number, [2]:number}
+---@alias snacks.picker.toggle {icon?:string, enabled?:boolean, value?:boolean}
 
 --- Generic filter used by finders to pre-filter items
 ---@class snacks.picker.filter.Config
@@ -166,6 +167,14 @@ local defaults = {
     tagstack = false, -- save the current position in the tagstack
     reuse_win = false, -- reuse an existing window if the buffer is already open
   },
+  ---@type table<string, string|false|snacks.picker.toggle>
+  toggles = {
+    follow = "f",
+    hidden = "h",
+    ignored = "i",
+    modified = "m",
+    regex = { icon = "R", value = false },
+  },
   win = {
     -- input window
     input = {
@@ -244,6 +253,8 @@ local defaults = {
         ["<ScrollWheelDown>"] = "list_scroll_wheel_down",
         ["<ScrollWheelUp>"] = "list_scroll_wheel_up",
         ["<c-a>"] = "select_all",
+        ["<a-m>"] = { "toggle_maximize" },
+        ["<a-p>"] = { "toggle_preview" },
         ["<c-f>"] = "preview_scroll_down",
         ["<c-b>"] = "preview_scroll_up",
         ["<c-l>"] = "preview_scroll_right",
@@ -256,6 +267,9 @@ local defaults = {
         ["<c-p>"] = "list_up",
         ["<a-w>"] = "cycle_win",
         ["<Esc>"] = "close",
+        ["<a-i>"] = "toggle_ignored",
+        ["<a-h>"] = "toggle_hidden",
+        ["<a-f>"] = "toggle_follow",
       },
       wo = {
         conceallevel = 2,

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -283,7 +283,7 @@ local defaults = {
     keymaps = {
       nowait = "󰓅 "
     },
-    indent = {
+    tree = {
       vertical    = "│ ",
       middle = "├╴",
       last   = "└╴",

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -98,6 +98,7 @@ local M = {}
 ---@field on_show? fun(picker:snacks.Picker) called when the picker is shown
 ---@field jump? snacks.picker.jump.Config|{}
 --- Other
+---@field config? fun(opts:snacks.picker.Config):snacks.picker.Config? custom config function
 ---@field debug? snacks.picker.debug|{}
 local defaults = {
   prompt = " ",

--- a/lua/snacks/picker/config/highlights.lua
+++ b/lua/snacks/picker/config/highlights.lua
@@ -12,10 +12,7 @@ Snacks.util.set_hl({
   File = "", -- basename of a file path
   Directory = "Directory", -- basename of a directory path
   Dir = "NonText", -- dirname of a path
-  Flag = "DiagnosticVirtualTextInfo",
-  FlagHidden = "SnacksPickerFlag",
-  FlagIgnored = "SnacksPickerFlag",
-  FlagFollow = "SnacksPickerFlag",
+  Toggle = "DiagnosticVirtualTextInfo",
   Dimmed = "Conceal",
   Row = "String",
   Col = "LineNr",

--- a/lua/snacks/picker/config/highlights.lua
+++ b/lua/snacks/picker/config/highlights.lua
@@ -9,12 +9,13 @@ Snacks.util.set_hl({
   Special = "Special",
   Label = "SnacksPickerSpecial",
   Totals = "NonText",
-  File = "",
+  File = "", -- basename of a file path
+  Directory = "Directory", -- basename of a directory path
+  Dir = "NonText", -- dirname of a path
   Flag = "DiagnosticVirtualTextInfo",
   FlagHidden = "SnacksPickerFlag",
   FlagIgnored = "SnacksPickerFlag",
   FlagFollow = "SnacksPickerFlag",
-  Dir = "NonText",
   Dimmed = "Conceal",
   Row = "String",
   Col = "LineNr",

--- a/lua/snacks/picker/config/highlights.lua
+++ b/lua/snacks/picker/config/highlights.lua
@@ -29,7 +29,7 @@ Snacks.util.set_hl({
   Unselected = "NonText",
   Idx = "Number",
   Bold = "Bold",
-  Indent = "LineNr",
+  Tree = "LineNr",
   Italic = "Italic",
   Code = "@markup.raw.markdown_inline",
   AuPattern = "String",

--- a/lua/snacks/picker/config/init.lua
+++ b/lua/snacks/picker/config/init.lua
@@ -82,6 +82,11 @@ function M.get(opts)
   elseif opts.cwd then
     opts.cwd = vim.fs.normalize(vim.fn.fnamemodify(opts.cwd, ":p"))
   end
+  for _, t in ipairs(todo) do
+    if t.config then
+      opts = t.config(opts) or opts
+    end
+  end
   M.multi(opts)
   return opts
 end

--- a/lua/snacks/picker/config/init.lua
+++ b/lua/snacks/picker/config/init.lua
@@ -87,6 +87,21 @@ function M.get(opts)
       opts = t.config(opts) or opts
     end
   end
+
+  -- add hl groups and actions for toggles
+  opts.actions = opts.actions or {}
+  for name in pairs(opts.toggles) do
+    local hl = table.concat(vim.tbl_map(function(a)
+      return a:sub(1, 1):upper() .. a:sub(2)
+    end, vim.split(name, "_")))
+    Snacks.util.set_hl({ [hl] = "SnacksPickerToggle" }, { default = true, prefix = "SnacksPickerToggle" })
+    opts.actions["toggle_" .. name] = function(picker)
+      picker.opts[name] = not picker.opts[name]
+      picker.list:set_target()
+      picker:find()
+    end
+  end
+
   M.multi(opts)
   return opts
 end

--- a/lua/snacks/picker/config/init.lua
+++ b/lua/snacks/picker/config/init.lua
@@ -77,8 +77,10 @@ function M.get(opts)
 
   -- Merge the configs
   opts = Snacks.config.merge(unpack(todo))
-  if opts.cwd == true then
+  if opts.cwd == true or opts.cwd == "" then
     opts.cwd = nil
+  elseif opts.cwd then
+    opts.cwd = vim.fs.normalize(vim.fn.fnamemodify(opts.cwd, ":p"))
   end
   M.multi(opts)
   return opts

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -417,13 +417,13 @@ M.lsp_references = {
 
 -- LSP document symbols
 ---@class snacks.picker.lsp.symbols.Config: snacks.picker.Config
----@field hierarchy? boolean show symbol hierarchy
+---@field tree? boolean show symbol tree
 ---@field filter table<string, string[]|boolean>? symbol kind filter
 ---@field workspace? boolean show workspace symbols
 M.lsp_symbols = {
   finder = "lsp_symbols",
   format = "lsp_symbol",
-  hierarchy = true,
+  tree = true,
   filter = {
     default = {
       "Class",
@@ -465,7 +465,7 @@ M.lsp_symbols = {
 ---@type snacks.picker.lsp.symbols.Config
 M.lsp_workspace_symbols = vim.tbl_extend("force", {}, M.lsp_symbols, {
   workspace = true,
-  hierarchy = false,
+  tree = false,
   supports_live = true,
   live = true, -- live by default
 })

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -16,6 +16,7 @@ M.autocmds = {
 ---@field unloaded? boolean show loaded buffers
 ---@field current? boolean show current buffer
 ---@field nofile? boolean show `buftype=nofile` buffers
+---@field modified? boolean show only modified buffers
 ---@field sort_lastused? boolean sort by last used
 ---@field filter? snacks.picker.filter.Config
 M.buffers = {
@@ -232,6 +233,7 @@ M.git_diff = {
 ---@field rtp? boolean search in runtimepath
 M.grep = {
   finder = "grep",
+  regex = true,
   format = "file",
   live = true, -- live grep by default
   supports_live = true,

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -37,6 +37,38 @@ M.buffers = {
   },
 }
 
+---@class snacks.picker.explorer.Config: snacks.picker.files.Config
+---@field follow_file? boolean follow the file from the current buffer
+---@field tree? boolean show the file tree (default: true)
+M.explorer = {
+  finder = "explorer",
+  sort = { fields = { "sort" } },
+  tree = true,
+  follow_file = true,
+  focus = "list",
+  auto_close = false,
+  layout = { preset = "sidebar", preview = false },
+  formatters = { file = { filename_only = true } },
+  matcher = { sort_empty = true },
+  config = function(opts)
+    return require("snacks.picker.source.explorer").setup(opts)
+  end,
+  win = {
+    list = {
+      keys = {
+        ["<BS>"] = "explorer_up",
+        ["a"] = "explorer_add",
+        ["d"] = "explorer_del",
+        ["r"] = "explorer_rename",
+        ["c"] = "explorer_copy",
+        ["y"] = "explorer_yank",
+        ["<c-c>"] = "explorer_cd",
+        ["."] = "explorer_focus",
+      },
+    },
+  },
+}
+
 M.cliphist = {
   finder = "system_cliphist",
   format = "text",
@@ -115,7 +147,7 @@ M.diagnostics_buffer = {
 }
 
 ---@class snacks.picker.files.Config: snacks.picker.proc.Config
----@field cmd? string
+---@field cmd? "fd"| "rg"| "find" command to use. Leave empty to auto-detect
 ---@field hidden? boolean show hidden files
 ---@field ignored? boolean show ignored files
 ---@field dirs? string[] directories to search

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -254,6 +254,7 @@ function M:init_layout(layout)
       self:update_titles()
       self:show_preview()
       self.input:update()
+      self.list:update_cursorline()
     end,
     layout = {
       backdrop = backdrop,

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -436,7 +436,11 @@ function M:show()
   if self.preview.main then
     self.preview.win:show()
   end
-  self.input.win:focus()
+  if self.opts.focus == "input" then
+    self.input.win:focus()
+  elseif self.opts.focus == "list" then
+    self.list.win:focus()
+  end
   if self.opts.on_show then
     self.opts.on_show(self)
   end

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -70,14 +70,16 @@ function M.new(opts)
     end,
   })
 
-  local picker_count = vim.tbl_count(M._pickers)
+  local picker_count = vim.tbl_count(M._pickers) - vim.tbl_count(M._active)
   if picker_count > 0 then
     -- clear items from previous pickers for garbage collection
     for picker, _ in pairs(M._pickers) do
-      picker.finder.items = {}
-      picker.list.items = {}
-      picker.list:clear()
-      picker.list.picker = nil
+      if not M._active[picker] then
+        picker.finder.items = {}
+        picker.list.items = {}
+        picker.list:clear()
+        picker.list.picker = nil
+      end
     end
   end
 

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -461,14 +461,14 @@ end
 
 --- Returns an iterator over the filtered items in the picker.
 --- Items will be in sorted order.
----@return fun():snacks.picker.Item?
+---@return fun():(snacks.picker.Item?, number?)
 function M:iter()
   local i = 0
   local n = self.list:count()
   return function()
     i = i + 1
     if i <= n then
-      return self:resolve(self.list:get(i))
+      return self:resolve(self.list:get(i)), i
     end
   end
 end

--- a/lua/snacks/picker/core/score.lua
+++ b/lua/snacks/picker/core/score.lua
@@ -5,7 +5,6 @@
 ---@field consecutive number
 ---@field prev? number
 ---@field prev_class number
----@field in_gap boolean
 ---@field is_file boolean
 ---@field first_bonus number
 ---@field str string
@@ -105,7 +104,6 @@ function M.new(opts)
   self.is_file = true
   self.consecutive = 0
   self.prev_class = CHAR_WHITE
-  self.in_gap = false
   self.str = ""
   self.first_bonus = 0
   return self
@@ -143,7 +141,6 @@ function M:init(str, first)
   then
     self.score = self.score + BONUS_NO_PATH_SEP
   end
-  self.in_gap = false
   self:update(first)
 end
 
@@ -157,14 +154,7 @@ function M:update(pos)
   if gap > 0 then
     self.prev_class = CHAR_CLASS[self.str:byte(pos - 1)] or CHAR_NONWORD
     bonus = BONUS_MATRIX[self.prev_class][class] or 0
-    if self.in_gap then
-      -- Already in a gap => extension penalty
-      self.score = self.score + gap * SCORE_GAP_EXTENSION
-    else
-      -- New gap => start penalty
-      self.score = self.score + SCORE_GAP_START + (gap - 1) * SCORE_GAP_EXTENSION
-      self.in_gap = true
-    end
+    self.score = self.score + SCORE_GAP_START + (gap - 1) * SCORE_GAP_EXTENSION
     self.consecutive = 0
     self.first_bonus = 0
   else
@@ -182,7 +172,6 @@ function M:update(pos)
       bonus = math.max(bonus, self.first_bonus, BONUS_CONSECUTIVE)
     end
     self.consecutive = self.consecutive + 1
-    self.in_gap = false
   end
 
   if not self.prev then

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -96,6 +96,10 @@ function M.file(item, picker)
     vim.list_extend(ret, M.severity(item, picker))
   end
 
+  if item.parent then
+    vim.list_extend(ret, M.indent(item, picker))
+  end
+
   vim.list_extend(ret, M.filename(item, picker))
 
   if item.comment then
@@ -191,7 +195,7 @@ function M.indent(item, picker)
   local indents = picker.opts.icons.indent
   local indent = {} ---@type string[]
   local node = item
-  while node and node.depth > 0 do
+  while node and node.parent do
     local is_last, icon = node.last, ""
     if node ~= item then
       icon = is_last and "  " or indents.vertical

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -97,7 +97,7 @@ function M.file(item, picker)
   end
 
   if item.parent then
-    vim.list_extend(ret, M.indent(item, picker))
+    vim.list_extend(ret, M.tree(item, picker))
   end
 
   vim.list_extend(ret, M.filename(item, picker))
@@ -190,22 +190,22 @@ function M.git_stash(item, picker)
   return ret
 end
 
-function M.indent(item, picker)
+function M.tree(item, picker)
   local ret = {} ---@type snacks.picker.Highlight[]
-  local indents = picker.opts.icons.indent
+  local icons = picker.opts.icons.tree
   local indent = {} ---@type string[]
   local node = item
   while node and node.parent do
     local is_last, icon = node.last, ""
     if node ~= item then
-      icon = is_last and "  " or indents.vertical
+      icon = is_last and "  " or icons.vertical
     else
-      icon = is_last and indents.last or indents.middle
+      icon = is_last and icons.last or icons.middle
     end
     table.insert(indent, 1, icon)
     node = node.parent
   end
-  ret[#ret + 1] = { table.concat(indent), "SnacksPickerIndent" }
+  ret[#ret + 1] = { table.concat(indent), "SnacksPickerTree" }
   return ret
 end
 
@@ -218,7 +218,7 @@ function M.undo(item, picker)
   else
     ret[#ret + 1] = { a("", 2) }
   end
-  vim.list_extend(ret, M.indent(item, picker))
+  vim.list_extend(ret, M.tree(item, picker))
 
   ret[#ret + 1] = { a(tostring(entry.seq), 4), "SnacksPickerIdx" }
   ret[#ret + 1] = { " " }
@@ -241,8 +241,8 @@ end
 function M.lsp_symbol(item, picker)
   local opts = picker.opts --[[@as snacks.picker.lsp.symbols.Config]]
   local ret = {} ---@type snacks.picker.Highlight[]
-  if item.hierarchy and not opts.workspace then
-    vim.list_extend(ret, M.indent(item, picker))
+  if item.tree and not opts.workspace then
+    vim.list_extend(ret, M.tree(item, picker))
   end
   local kind = item.kind or "Unknown" ---@type string
   local kind_hl = "SnacksPickerIcon" .. kind

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -43,26 +43,33 @@ function M.filename(item, picker)
 
   if picker.opts.icons.files.enabled ~= false then
     local icon, hl = Snacks.util.icon(name, cat)
+    if item.dir and item.open then
+      icon = " "
+    end
     local padded_icon = icon:sub(-1) == " " and icon or icon .. " "
     ret[#ret + 1] = { padded_icon, hl, virtual = true }
   end
 
-  local dir, file = path:match("^(.*)/(.+)$")
+  local base_hl = item.dir and "SnacksPickerDirectory" or "SnacksPickerFile"
+  local dir_hl = "SnacksPickerDir"
+
   if picker.opts.formatters.file.filename_only then
-    dir = nil
     path = vim.fn.fnamemodify(path, ":t")
-  end
-  if file and dir then
-    if picker.opts.formatters.file.filename_first then
-      ret[#ret + 1] = { file, "SnacksPickerFile", field = "file" }
-      ret[#ret + 1] = { " " }
-      ret[#ret + 1] = { dir, "SnacksPickerDir", field = "file" }
-    else
-      ret[#ret + 1] = { dir .. "/", "SnacksPickerDir", field = "file" }
-      ret[#ret + 1] = { file, "SnacksPickerFile", field = "file" }
-    end
+    ret[#ret + 1] = { path, base_hl, field = "file" }
   else
-    ret[#ret + 1] = { path, "SnacksPickerFile", field = "file" }
+    local dir, base = path:match("^(.*)/(.+)$")
+    if base and dir then
+      if picker.opts.formatters.file.filename_first then
+        ret[#ret + 1] = { base, base_hl, field = "file" }
+        ret[#ret + 1] = { " " }
+        ret[#ret + 1] = { dir, dir_hl, field = "file" }
+      else
+        ret[#ret + 1] = { dir .. "/", dir_hl, field = "file" }
+        ret[#ret + 1] = { base, base_hl, field = "file" }
+      end
+    else
+      ret[#ret + 1] = { path, base_hl, field = "file" }
+    end
   end
   if item.pos and item.pos[1] > 0 then
     ret[#ret + 1] = { ":", "SnacksPickerDelim" }

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -57,6 +57,9 @@ function M.filename(item, picker)
     path = vim.fn.fnamemodify(path, ":t")
     ret[#ret + 1] = { path, base_hl, field = "file" }
   else
+    if item.dir then
+      path = path .. "/"
+    end
     local dir, base = path:match("^(.*)/(.+)$")
     if base and dir then
       if picker.opts.formatters.file.filename_first then

--- a/lua/snacks/picker/init.lua
+++ b/lua/snacks/picker/init.lua
@@ -17,6 +17,9 @@ local M = setmetatable({}, {
   end,
   ---@param M snacks.picker
   __index = function(M, k)
+    if k == "current" then
+      return nil
+    end
     if type(k) ~= "string" then
       return
     end
@@ -68,6 +71,10 @@ function M.pick(source, opts)
   if not (opts.source or opts.items or opts.finder or opts.multi) then
     opts.source = "pickers"
     return M.pick(opts)
+  end
+  if opts.source and M.current and M.current.opts.source == opts.source then
+    M.current:close()
+    return
   end
   return require("snacks.picker.core.picker").new(opts)
 end

--- a/lua/snacks/picker/source/buffers.lua
+++ b/lua/snacks/picker/source/buffers.lua
@@ -21,6 +21,7 @@ function M.buffers(opts, ctx)
       and (opts.unloaded or vim.api.nvim_buf_is_loaded(buf))
       and (opts.current or buf ~= current_buf)
       and (opts.nofile or vim.bo[buf].buftype ~= "nofile")
+      and (not opts.modified or vim.bo[buf].modified)
     if keep then
       local name = vim.api.nvim_buf_get_name(buf)
       if name == "" then

--- a/lua/snacks/picker/source/explorer.lua
+++ b/lua/snacks/picker/source/explorer.lua
@@ -1,0 +1,439 @@
+local M = {}
+
+---@type table<snacks.Picker, snacks.picker.explorer.State>
+M._state = setmetatable({}, { __mode = "k" })
+local uv = vim.uv or vim.loop
+
+---@class snacks.picker.explorer.Item: snacks.picker.finder.Item
+---@field file string
+---@field dir? boolean
+---@field parent? snacks.picker.explorer.Item
+---@field open? boolean
+
+---@class snacks.picker.explorer.State
+---@field cwd string
+---@field expanded table<string, boolean>
+---@field all? boolean
+---@field picker snacks.Picker.ref
+---@field opts snacks.picker.explorer.Config
+---@field on_find? fun()?
+local State = {}
+State.__index = State
+---@param picker snacks.Picker
+function State.new(picker)
+  local self = setmetatable({}, State)
+  self.opts = picker.opts --[[@as snacks.picker.explorer.Config]]
+  self.picker = picker:ref()
+  local filter = picker:filter()
+  self.cwd = filter.cwd
+  self.expanded = { [self.cwd] = true }
+  local buf = vim.api.nvim_win_get_buf(picker.main)
+  local buf_file = vim.fs.normalize(vim.api.nvim_buf_get_name(buf))
+  if uv.fs_stat(buf_file) then
+    self:expand(buf_file)
+  end
+  picker.list.win:on({ "WinEnter", "BufEnter" }, function()
+    self:follow()
+  end)
+  -- schedule initial follow
+  if self.opts.follow_file then
+    self.on_find = function()
+      self.on_find = nil
+      self:show(buf_file)
+    end
+  end
+  return self
+end
+
+function State:follow()
+  if not self.opts.follow_file then
+    return
+  end
+  local picker = self.picker()
+  if not picker or picker:is_focused() then
+    return
+  end
+  local buf = vim.api.nvim_get_current_buf()
+  local file = vim.api.nvim_buf_get_name(buf)
+  self:show(file)
+end
+
+---@param path string
+function State:show(path)
+  local picker = self.picker()
+  if not picker then
+    return
+  end
+  path = vim.fs.normalize(path)
+  if not uv.fs_stat(path) then
+    return
+  end
+  local function show()
+    for item, idx in picker:iter() do
+      if item.file == path then
+        picker.list:view(idx)
+        break
+      end
+    end
+  end
+  if not self:is_visible(path) then
+    self:expand(path)
+    self:update({ on_done = show })
+  else
+    show()
+  end
+end
+
+---@param path string
+function State:is_visible(path)
+  local dir = vim.fn.isdirectory(path) == 1 and path or vim.fs.dirname(path)
+  if not self:in_cwd(dir) then
+    return false
+  end
+  if not self.expanded[dir] then
+    return false
+  end
+  for p, v in pairs(self.expanded) do
+    if not v and p:find(dir .. "/", 1, true) == 1 then
+      return false
+    end
+  end
+  return true
+end
+
+---@param dir string
+function State:is_open(dir)
+  return self.expanded[dir]
+end
+
+function State:in_cwd(path)
+  return path == self.cwd or path:find(self.cwd .. "/", 1, true) == 1
+end
+
+---@param path string
+function State:expand(path)
+  if not self:in_cwd(path) then
+    return
+  end
+  if vim.fn.isdirectory(path) == 1 then
+    self.expanded[path] = true
+  else
+    self.expanded[vim.fs.dirname(path)] = true
+  end
+  for p in vim.fs.parents(path) do
+    if not self:in_cwd(p) then
+      break
+    end
+    self.expanded[p] = true
+  end
+end
+
+---@param item snacks.picker.Item
+function State:toggle(item)
+  local dir = Snacks.picker.util.path(item)
+  if not dir then
+    return
+  end
+  self.expanded[dir] = not self.expanded[dir]
+  if self.expanded[dir] then
+    self:expand(dir)
+  end
+  self:update()
+end
+
+function State:expand_dirs()
+  local expand = {} ---@type table<string, boolean>
+  local exclude = {} ---@type table<string, boolean>
+  for k, v in pairs(self.expanded) do
+    if self:in_cwd(k) then
+      (v and expand or exclude)[k] = true
+    end
+  end
+  -- remove excluded directories
+  for p in pairs(expand) do
+    for e in pairs(exclude) do
+      if p:find(e .. "/", 1, true) == 1 then
+        expand[p] = nil
+        break
+      end
+    end
+  end
+  local ret = vim.tbl_keys(expand) ---@type string[]
+  -- add parents
+  for p in pairs(expand) do
+    for pp in vim.fs.parents(p) do
+      if expand[pp] or not self:in_cwd(pp) then
+        break
+      end
+      expand[pp] = true
+      ret[#ret + 1] = pp
+    end
+  end
+  return ret
+end
+
+---@param opts snacks.picker.explorer.Config
+function State:setup(opts)
+  opts = Snacks.picker.util.shallow_copy(opts)
+  opts.cmd = "fd"
+  opts.cwd = self.cwd
+  opts.args = { "--type", "d", "--path-separator", "/" }
+  if not self.all then
+    opts.dirs = self:expand_dirs()
+    vim.list_extend(opts.args, { "--max-depth", "1" })
+  end
+  return opts
+end
+
+---@param opts? {target?: boolean, on_done?: fun()}
+function State:update(opts)
+  opts = opts or {}
+  local picker = self.picker()
+  if not picker then
+    return
+  end
+  if opts.target ~= false then
+    picker.list:set_target()
+  end
+  picker:find({ on_done = opts.on_done })
+end
+
+function State:dir()
+  local picker = self.picker()
+  if not picker then
+    return self.cwd
+  end
+  local item = picker:current()
+  if item and item.dir then
+    return item.file
+  elseif item then
+    return vim.fn.fnamemodify(item.file, ":h")
+  else
+    return self.cwd
+  end
+end
+
+function State:set_cwd(cwd)
+  self.cwd = cwd
+  self.expanded[cwd] = true
+  for k in pairs(self.expanded) do
+    if not self:in_cwd(k) then
+      self.expanded[k] = nil
+    end
+  end
+  self:update({ target = false })
+end
+
+function State:up()
+  self:set_cwd(vim.fs.dirname(self.cwd))
+end
+
+---@param opts snacks.picker.explorer.Config
+function M.setup(opts)
+  return Snacks.config.merge(opts, {
+    actions = M.actions,
+    formatters = {
+      file = {
+        filename_only = opts.tree,
+      },
+    },
+  })
+end
+
+---@type table<string, snacks.picker.Action.spec>
+M.actions = {
+  explorer_up = function(picker)
+    dd("explorer_up")
+    M.get_state(picker):up()
+  end,
+  explorer_add = function(picker)
+    local state = M.get_state(picker)
+    Snacks.input({
+      prompt = 'Add a new file or directory (directories end with a "/")',
+    }, function(value)
+      if not value or value:find("^%s$") then
+        return
+      end
+      local dir = state:dir()
+      local path = vim.fs.normalize(dir .. "/" .. value)
+      local is_dir = value:sub(-1) == "/"
+      dir = is_dir and path or vim.fs.dirname(path)
+      vim.fn.mkdir(dir, "p")
+      state:expand(dir)
+      if not is_dir then
+        if uv.fs_stat(path) then
+          Snacks.notify.warn("File already exists:\n- `" .. path .. "`")
+          return
+        end
+        io.open(path, "w"):close()
+      end
+      state:update()
+    end)
+  end,
+  explorer_rename = function(picker, item)
+    if not item then
+      return
+    end
+    local state = M.get_state(picker)
+    Snacks.rename.rename_file({
+      file = item.file,
+      on_rename = function(new)
+        state:expand(new)
+        state:update()
+      end,
+    })
+  end,
+  explorer_copy = function(picker, item)
+    if not item then
+      return
+    end
+    if item.dir then
+      Snacks.notify.warn("Cannot copy directories")
+      return
+    end
+    local state = M.get_state(picker)
+    Snacks.input({
+      prompt = "Copy to",
+    }, function(value)
+      if not value or value:find("^%s$") then
+        return
+      end
+      local dir = state:dir()
+      local path = vim.fs.normalize(dir .. "/" .. value)
+      vim.fn.mkdir(vim.fs.dirname(path), "p")
+      state:expand(dir)
+      if uv.fs_stat(path) then
+        Snacks.notify.warn("File already exists:\n- `" .. path .. "`")
+        return
+      end
+      uv.fs_copyfile(item.file, path, function(err)
+        if err then
+          Snacks.notify.error("Failed to copy `" .. item.file .. "` to `" .. path .. "`:\n- " .. err)
+        end
+        state:update()
+      end)
+    end)
+  end,
+  explorer_del = function(picker)
+    local state = M.get_state(picker)
+    ---@type string[]
+    local paths = vim.tbl_map(Snacks.picker.util.path, picker:selected({ fallback = true }))
+    if #paths == 0 then
+      return
+    end
+    local what = #paths == 1 and vim.fn.fnamemodify(paths[1], ":p:~:.") or #paths .. " files"
+    Snacks.picker.select({ "Yes", "No" }, { prompt = "Delete " .. what .. "?" }, function(_, idx)
+      if idx == 1 then
+        for _, path in ipairs(paths) do
+          local ok, err = pcall(vim.fn.delete, path, "rf")
+          if not ok then
+            Snacks.notify.error("Failed to delete `" .. path .. "`:\n- " .. err)
+          end
+        end
+        state:update()
+      end
+    end)
+  end,
+  explorer_focus = function(picker)
+    local state = M.get_state(picker)
+    state:set_cwd(state:dir())
+  end,
+  explorer_yank = function(picker, item)
+    if not item then
+      return
+    end
+    vim.fn.setreg("+", item.file)
+    Snacks.notify.info("Yanked `" .. item.file .. "`")
+  end,
+  explorer_cd = function(picker, item)
+    local state = M.get_state(picker)
+    vim.fn.chdir(state:dir())
+    state:set_cwd(vim.fn.getcwd())
+  end,
+  confirm = function(picker)
+    local state = M.get_state(picker)
+    local item = picker:current()
+    if not item then
+      return
+    elseif item.dir then
+      state:toggle(item)
+    else
+      picker:action("jump")
+    end
+  end,
+}
+
+---@param picker snacks.Picker
+function M.get_state(picker)
+  if not M._state[picker] then
+    M._state[picker] = State.new(picker)
+  end
+  return M._state[picker]
+end
+
+---@param opts snacks.picker.explorer.Config
+---@type snacks.picker.finder
+function M.explorer(opts, ctx)
+  local state = M.get_state(ctx.picker)
+  opts = state:setup(opts)
+
+  local files = require("snacks.picker.source.files").files(opts, ctx)
+  local dirs = {} ---@type table<string, snacks.picker.explorer.Item>
+  local last = {} ---@type table<snacks.picker.finder.Item, snacks.picker.finder.Item>
+
+  ---@type snacks.picker.explorer.Item
+  local root = {
+    file = state.cwd,
+    dir = true,
+    open = true,
+    text = "",
+    hello = "world",
+    sort = "",
+  }
+
+  return function(cb)
+    if state.on_find then
+      ctx.picker.matcher.task:on("done", vim.schedule_wrap(state.on_find))
+    end
+    cb(root)
+    files(function(item)
+      ---@cast item snacks.picker.explorer.Item
+
+      -- Directories
+      if item.file:sub(-1) == "/" then
+        item.dir = true
+        item.file = item.file:sub(1, -2)
+        item.open = state:is_open(item.file)
+        dirs[item.file] = item
+      end
+
+      local dirname, basename = item.file:match("(.*)/(.*)")
+      dirname, basename = dirname or "", basename or item.file
+      local parent = dirs[dirname] ~= item and dirs[dirname] or root
+
+      -- hierarchical sorting
+      if item.dir then
+        item.sort = parent.sort .. "/0" .. basename
+      else
+        item.sort = parent.sort .. "/1" .. basename
+      end
+
+      if opts.tree then
+        -- tree
+        item.parent = parent
+        if not last[parent] or last[parent].sort < item.sort then
+          if last[parent] then
+            last[parent].last = false
+          end
+          item.last = true
+          last[parent] = item
+        end
+      end
+
+      -- add to picker
+      cb(item)
+    end)
+  end
+end
+
+return M

--- a/lua/snacks/picker/source/lsp.lua
+++ b/lua/snacks/picker/source/lsp.lua
@@ -272,7 +272,6 @@ function M.results_to_items(client, results, opts)
     local item = {
       kind = M.symbol_kind(result.kind),
       parent = parent,
-      depth = (parent.depth or 0) + 1,
       detail = result.detail,
       name = result.name,
       text = "",
@@ -299,7 +298,7 @@ function M.results_to_items(client, results, opts)
     result.children = nil
   end
 
-  local root = { depth = 0, text = "" } ---@type snacks.picker.finder.Item
+  local root = { text = "" } ---@type snacks.picker.finder.Item
   ---@type snacks.picker.finder.Item
   for _, result in ipairs(results) do
     add(result, root)

--- a/lua/snacks/picker/source/lsp.lua
+++ b/lua/snacks/picker/source/lsp.lua
@@ -369,7 +369,7 @@ function M.symbols(opts, ctx)
         end,
       })
       for _, item in ipairs(items) do
-        item.hierarchy = opts.hierarchy
+        item.tree = opts.tree
         ---@diagnostic disable-next-line: await-in-sync
         cb(item)
       end

--- a/lua/snacks/picker/source/lsp.lua
+++ b/lua/snacks/picker/source/lsp.lua
@@ -281,7 +281,7 @@ function M.results_to_items(client, results, opts)
     local loc = result.location or { range = result.selectionRange or result.range, uri = uri }
     loc.uri = loc.uri or uri
     M.add_loc(item, loc, client)
-    local text = table.concat({ M.symbol_kind(result.kind), result.name, result.detail or "" }, " ")
+    local text = table.concat({ M.symbol_kind(result.kind), result.name }, " ")
     if opts.text_with_file and item.file then
       text = text .. " " .. item.file
     end

--- a/lua/snacks/picker/source/snacks.lua
+++ b/lua/snacks/picker/source/snacks.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---@param opts snacks.picker.notifications.Config
 function M.notifier(opts)
-  local notifs = Snacks.notifier.get_history({ filter = opts.filter })
+  local notifs = Snacks.notifier.get_history({ filter = opts.filter, reverse = true })
   local items = {} ---@type snacks.picker.finder.Item[]
 
   for _, notif in ipairs(notifs) do

--- a/lua/snacks/picker/source/vim.lua
+++ b/lua/snacks/picker/source/vim.lua
@@ -396,7 +396,6 @@ function M.undo(opts, ctx)
         current = entry.seq == tree.seq_cur,
         last = e == #entries,
         parent = parent,
-        depth = parent and parent.depth + 1 or 1,
         action = function()
           vim.api.nvim_buf_call(buf, function()
             vim.cmd("undo " .. entry.seq)


### PR DESCRIPTION
## Description

File explorer picker.

## Testing

```lua
{
  { "nvim-neo-tree/neo-tree.nvim", enabled = false },
  {
    "folke/snacks.nvim",
    keys = {
      { "<leader>e", function() Snacks.picker.explorer() end, desc = "Explorer Snacks" },
    },
    init = function()
      vim.api.nvim_create_autocmd("BufEnter", {
        group = vim.api.nvim_create_augroup("snacks_explorer_start_directory", { clear = true }),
        desc = "Start Snacks Explorer with directory",
        once = true,
        callback = function()
          local dir = vim.fn.argv(0) --[[@as string]]
          if dir ~= "" and vim.fn.isdirectory(dir) == 1 then
            Snacks.picker.explorer({ cwd = dir })
          end
        end,
      })
    end,
  },
}
```

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

![image](https://github.com/user-attachments/assets/e71f8f93-6987-41d5-9778-6661affe34b0)

