### PR TITLE
fix(git): fix git root detection

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -24,10 +24,10 @@ function M.files(opts, ctx)
     table.insert(args, "--recurse-submodules")
   end
   if not opts.cwd then
-    opts.cwd = Snacks.git.get_root()
+    opts.cwd = Snacks.git.get_root() or uv.cwd() or "."
     ctx.picker:set_cwd(opts.cwd)
   end
-  local cwd = vim.fs.normalize(opts and opts.cwd or uv.cwd() or ".") or nil
+  local cwd = vim.fs.normalize(opts.cwd) or nil
   return require("snacks.picker.source.proc").proc({
     opts,
     {
@@ -186,7 +186,7 @@ function M.branches(opts, ctx)
     --- e.g. "* (HEAD detached at f65a2c8) f65a2c8 chore(build): auto-generate docs"
     "^(.)%s(%b())%s+(" .. commit_pat .. ")%s*(.*)$",
     --- e.g. "  main                       d2b2b7b [origin/main: behind 276] chore(build): auto-generate docs"
-    "^(.)%s(%S+)%s+(".. commit_pat .. ")%s*(.*)$",
+    "^(.)%s(%S+)%s+(" .. commit_pat .. ")%s*(.*)$",
     -- stylua: ignore end
   } ---@type string[]
 


### PR DESCRIPTION
## Description

Regression was introduced in 3cdebee880742970df1a1f685be4802b90642c7d (#751)

Fix git root detection for bare repositories.

With bare repositories, the `.git` search in parent folders might not work, in which case the picker fails with:

```
E5108: Error executing lua: vim/shared.lua:0: s: expected string, got nil
stack traceback:
	[C]: in function 'error'
	vim/shared.lua: in function 'validate'
	vim/shared.lua: in function 'startswith'
	vim/fs.lua: in function 'normalize'
	.../nvim/lazy/snacks.nvim/lua/snacks/picker/core/filter.lua:57: in function 'set_cwd'
	.../nvim/lazy/snacks.nvim/lua/snacks/picker/core/picker.lua:700: in function 'set_cwd'
	...e/nvim/lazy/snacks.nvim/lua/snacks/picker/source/git.lua:28: in function '_find'
	.../nvim/lazy/snacks.nvim/lua/snacks/picker/core/finder.lua:119: in function 'run'
	.../nvim/lazy/snacks.nvim/lua/snacks/picker/core/picker.lua:741: in function 'find'
	.../nvim/lazy/snacks.nvim/lua/snacks/picker/core/picker.lua:201: in function 'git_files'
	/Users/lttb/.config/nvim/lua/lttb/plugins/snacks.lua:96: in function </Users/lttb/.config/nvim/lua/lttb/plugins/snacks.lua:95>
```

- this fix introduces `git rev-parse --show-toplevel`, with the previous '.git' search logic as a fallback.
- it also updates the caching logic a bit, to populate the cache with `git_root` on the way to the root directory, to optimise a bit git root detection from other sub directories and avoid system calls