### PR TITLE
feat(scope): allow injected languages to be parsed by treesitter

### DIFF
--- a/lua/snacks/scope.lua
+++ b/lua/snacks/scope.lua
@@ -43,6 +43,7 @@ local defaults = {
     -- detect scope based on treesitter.
     -- falls back to indent based detection if not available
     enabled = true,
+    ignore_injections = false, -- do not ignore injected languages, helpful for languages like vue
     ---@type string[]|{enabled?:boolean}
     blocks = {
       enabled = false, -- enable to use the following blocks
@@ -410,7 +411,12 @@ function TSScope:find(opts)
     (vim.fn.getline(line):find("%S") or 1) - 1, -- find first non-space character
   }
 
-  local node = vim.treesitter.get_node({ pos = pos, bufnr = opts.buf, lang = lang })
+  local node = vim.treesitter.get_node({
+    pos = pos,
+    bufnr = opts.buf,
+    lang = lang,
+    ignore_injections = opts.treesitter.ignore_injections,
+  })
   if not node then
     return
   end

--- a/lua/snacks/scope.lua
+++ b/lua/snacks/scope.lua
@@ -401,7 +401,7 @@ function TSScope:find(opts)
   if not has_parser or parser == nil then
     return
   end
-  parser:parse(true)
+  parser:parse(opts.treesitter.injections)
 
   local line = vim.fn.nextnonblank(opts.pos[1])
   line = line == 0 and vim.fn.prevnonblank(opts.pos[1]) or line

--- a/lua/snacks/scope.lua
+++ b/lua/snacks/scope.lua
@@ -43,7 +43,7 @@ local defaults = {
     -- detect scope based on treesitter.
     -- falls back to indent based detection if not available
     enabled = true,
-    ignore_injections = false, -- do not ignore injected languages, helpful for languages like vue
+    injections = true, -- include language injections when detecting scope (useful for languages like `vue`)
     ---@type string[]|{enabled?:boolean}
     blocks = {
       enabled = false, -- enable to use the following blocks
@@ -415,7 +415,7 @@ function TSScope:find(opts)
     pos = pos,
     bufnr = opts.buf,
     lang = lang,
-    ignore_injections = opts.treesitter.ignore_injections,
+    ignore_injections = not opts.treesitter.injections,
   })
   if not node then
     return


### PR DESCRIPTION
## Description

Adding a config flag to allow injected languages to be parsed by treesitter. This is crucial for languages like vue, which contain typescript or javascript in a script tag. When `treesitter.get_node` is not called with ignore_injections = false, the script tag is treated as a single block, which is not helpful, as it contains most code for languages like vue.

## Related Issue(s)

 - Fixes #430 

## Screenshots

 - See #430 

