### PR TITLE
fix(picker): enforce bottom positioning for quickfix and location lists

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -258,10 +258,10 @@ local function setqflist(items, opts)
   end
   if opts and opts.win then
     vim.fn.setloclist(opts.win, qf)
-    vim.cmd("lopen")
+    vim.cmd("botright lopen")
   else
     vim.fn.setqflist(qf)
-    vim.cmd("copen")
+    vim.cmd("botright copen")
   end
 end
 


### PR DESCRIPTION
## Description

This PR addresses an issue where the quickfix list (qflist) would open on the left side of the screen when using vertical splits. By replacing the default :copen command with :botright copen, this update ensures that the qflist consistently opens at the bottom, regardless of the current window layout.

## Reproduce:

1. Open Neovim: Start Neovim normally.
2. Create a Vertical Split
3. Use picker to pick anything
4. Press <c-q> to send them to quickfix list

```lua
vim.env.LAZY_STDPATH = ".repro"
load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()

vim.g.mapleader = " "

require("lazy.minit").repro({
	spec = {
		{
			"Isrothy/snacks.nvim",
			branch = "bottom-positioning-for-qf",
			lazy = false,
			keys = {
				{
					"<LEADER>ff",
					function()
						Snacks.picker.files()
					end,
					desc = "Files",
				},
			opts = {},
		},
		-- add any other plugins here
	},
})

```

## Screenshots

before:
<img width="1439" alt="Screenshot 2025-01-31 at 23 48 59" src="https://github.com/user-attachments/assets/d21b9668-ff4d-4464-84b4-48c47c48153a" />

after:
<img width="1438" alt="Screenshot 2025-01-31 at 23 50 11" src="https://github.com/user-attachments/assets/6aba0840-2125-4336-92e2-7152e8669aa6" />



