### PR TITLE
feat(picker.commands): do not autorun commands that require arguments

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -386,6 +386,13 @@ function M.cmd(picker, item)
   picker:close()
   if item and item.cmd then
     vim.schedule(function()
+      if item.command and (item.command.nargs == "1" or item.command.nargs == "*" or item.command.nargs == "?") then
+        local keys = ":" .. item.cmd .. " "
+        local escaped = vim.api.nvim_replace_termcodes(keys, true, false, true)
+
+        return vim.api.nvim_feedkeys(escaped, "n", true)
+      end
+
       vim.cmd(item.cmd)
     end)
   end

--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -386,14 +386,11 @@ function M.cmd(picker, item)
   picker:close()
   if item and item.cmd then
     vim.schedule(function()
-      if item.command and (item.command.nargs == "1" or item.command.nargs == "*" or item.command.nargs == "?") then
-        local keys = ":" .. item.cmd .. " "
-        local escaped = vim.api.nvim_replace_termcodes(keys, true, false, true)
-
-        return vim.api.nvim_feedkeys(escaped, "n", true)
+      if item.command and (item.command.nargs ~= "0") then
+        vim.api.nvim_input(":" .. item.cmd .. " ")
+      else
+        vim.cmd(item.cmd)
       end
-
-      vim.cmd(item.cmd)
     end)
   end
 end

--- a/lua/snacks/picker/source/vim.lua
+++ b/lua/snacks/picker/source/vim.lua
@@ -15,8 +15,6 @@ local M = {}
 ---@class snacks.picker.history.Config: snacks.picker.Config
 ---@field name string
 
-local uv = vim.uv or vim.loop
-
 function M.commands()
   local commands = vim.api.nvim_get_commands({})
   for k, v in pairs(vim.api.nvim_buf_get_commands(0, {})) do


### PR DESCRIPTION
## Description

Currently when you use picker.commands to select a command that requires an argument, it will cause an error. `:BlickCmd` is one example. To avoid the error we can feed the keys to enter the command mode and populate the command and leave it to the user what they want to do. 

This is also what telescope [does](https://github.com/nvim-telescope/telescope.nvim/blob/415af52339215926d705cccc08145f3782c4d132/lua/telescope/builtin/__internal.lua#L399) in its builtin command picker.

nargs values `*` or `?` mean that the command can be executed both with arguments and without. I think it is safer to leave it to the user to decide if they want them to either trigger a run or provide the arguments. But happy to change it if you think running the commands by default makes sense.