### PR TITLE
feat(picker.matcher): add option to enable/disable boundary bonus

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -126,6 +126,7 @@ local defaults = {
     -- so this can have a performance impact for large lists and increase memory usage
     cwd_bonus = false, -- give bonus for matching files in the cwd
     frecency = false, -- frecency bonus
+    boundary_case_bonus = true, -- give boundary/camel bonus
   },
   sort = {
     -- default sort is by score, text length and index

--- a/lua/snacks/picker/core/score.lua
+++ b/lua/snacks/picker/core/score.lua
@@ -177,6 +177,9 @@ function M:update(pos)
   if not self.prev then
     bonus = (bonus * BONUS_FIRST_CHAR_MULTIPLIER)
   end
+  if not self.opts.boundary_case_bonus then
+    bonus = 0
+  end
 
   self.score = self.score + SCORE_MATCH + bonus
 


### PR DESCRIPTION
## Description

I have a picker to search my bash history to execute a bash command in a Snacks.terminal. I'd like to have the same order of search results as when using `fzf` with `--scheme=history`.
Using `  sort = { fields = { "score:desc", "idx" } },` together with the new option to disable the boundary bonus, seems to give me the same results.

