### PR TITLE
fix(picker.git_log): add extra space between the date and the message

### DIFF
--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -129,9 +129,10 @@ function M.git_log(item, picker)
   if item.date then
     ret[#ret + 1] = { a(item.date, 16), "SnacksPickerGitDate" }
   end
+  ret[#ret + 1] = { " " }
 
   local msg = item.msg ---@type string
-  local type, scope, breaking, body = msg:match("^(%S+)(%(.-%))(!?):%s*(.*)$")
+  local type, scope, breaking, body = msg:match("^(%S+)%s*(%(.-%))(!?):%s*(.*)$")
   if not type then
     type, breaking, body = msg:match("^(%S+)(!?):%s*(.*)$")
   end


### PR DESCRIPTION
## Description

Add additional space between the date of the commit and the commit message so that the message is more readable. Also added support for spaces between the type and the scope of the commit.

## Screenshots

Before:

![image](https://github.com/user-attachments/assets/446480cd-0165-4421-9e63-29bfc7188011)

![image](https://github.com/user-attachments/assets/d75fbe6c-394e-4d97-aad9-ca3e7d3cd35c)

After:

![image](https://github.com/user-attachments/assets/8f1ac512-d723-4f5b-81de-000d794ad7a4)

![image](https://github.com/user-attachments/assets/273a0cac-c927-4ad2-9b51-737daa60c56a)
