### PR TITLE
feat(picker): add create and delete branch to git_branches

### DIFF
--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -1171,6 +1171,14 @@ GIT_BRANCHES                              *snacks-picker-sources-git_branches*
       format = "git_branch",
       preview = "git_log",
       confirm = "git_checkout",
+      win = {
+	input = {
+	  keys = {
+	    ["<c-a>"] = { "git_create_branch", mode = { "n", "i" } },
+	    ["<c-x>"] = { "git_delete_branch", mode = { "n", "i" } },
+	  },
+	},
+      },
       on_show = function(picker)
         for i, item in ipairs(picker:items()) do
           if item.current then

--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -1172,12 +1172,12 @@ GIT_BRANCHES                              *snacks-picker-sources-git_branches*
       preview = "git_log",
       confirm = "git_checkout",
       win = {
-	input = {
-	  keys = {
-	    ["<c-a>"] = { "git_create_branch", mode = { "n", "i" } },
-	    ["<c-x>"] = { "git_delete_branch", mode = { "n", "i" } },
-	  },
-	},
+        input = {
+          keys = {
+            ["<c-a>"] = { "git_create_branch", mode = { "n", "i" } },
+            ["<c-x>"] = { "git_delete_branch", mode = { "n", "i" } },
+          },
+        },
       },
       on_show = function(picker)
         for i, item in ipairs(picker:items()) do

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -190,6 +190,14 @@ M.git_branches = {
   format = "git_branch",
   preview = "git_log",
   confirm = "git_checkout",
+  win = {
+    input = {
+      keys = {
+        ["<c-a>"] = { "git_create_branch", mode = { "n", "i" } },
+        ["<c-x>"] = { "git_delete_branch", mode = { "n", "i" } },
+      },
+    },
+  },
   on_show = function(picker)
     for i, item in ipairs(picker:items()) do
       if item.current then


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

This PR adds two actions: `git_create_branch` and `git_delete_branch`. They are aimed to be included in the `git_branches` picker to easily create/delete git branches with custom keymaps.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

