### PR TITLE
feat(picker): do not save empty patterns as last

### DIFF
--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -627,14 +627,16 @@ function M:close()
   self:hist_record(true)
   self.closed = true
 
-  M.last = {
-    opts = self.init_opts or {},
-    selected = self:selected({ fallback = false }),
-    cursor = self.list.cursor,
-    topline = self.list.top,
-    filter = self.input.filter,
-  }
-  M.last.opts.live = self.opts.live
+  if self.input.filter.pattern ~= "" then
+    M.last = {
+      opts = self.init_opts or {},
+      selected = self:selected({ fallback = false }),
+      cursor = self.list.cursor,
+      topline = self.list.top,
+      filter = self.input.filter,
+    }
+    M.last.opts.live = self.opts.live
+  end
 
   local current = vim.api.nvim_get_current_win()
   local is_picker_win = vim.tbl_contains({ self.input.win.win, self.list.win.win, self.preview.win.win }, current)


### PR DESCRIPTION
## Description

Maybe it's just me, but it occurs sometimes that I launch picker, and I immediately realize that I should have just resumed the last search. However, at this point I cannot do so, because my freshly open (empty) picker will overwrite the `M.last`. I think it'd make sense to overwrite `M.last` only when the currently open picker is not empty. Otherwise, resuming does not really give any benefit.

## Related Issues

Closes #1130 