### PR TITLE
docs(rename): add oil.nvim integration

### DIFF
--- a/docs/rename.md
+++ b/docs/rename.md
@@ -16,6 +16,19 @@ vim.api.nvim_create_autocmd("User", {
 })
 ```
 
+## [oil.nvim](https://github.com/stevearc/oil.nvim)
+
+```lua
+vim.api.nvim_create_autocmd("User", {
+  pattern = "OilActionsPost",
+  callback = function(event)
+      if event.data.actions.type == "move" then
+          Snacks.rename.on_rename_file(event.data.actions.src_url, event.data.actions.dest_url)
+      end
+  end,
+})
+```
+
 ## [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim)
 
 ```lua


### PR DESCRIPTION
## Description

Add an autocmd for oil.nvim integration of snacks.rename to the docs, similar to mini.files.

