### PR TITLE
feat(picker.scratch)

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -833,4 +833,36 @@ M.zoxide = {
   },
 }
 
+M.scratch = {
+  finder = "files_scratch",
+  format = "file",
+  win = {
+    preview = { wo = { number = false, relativenumber = false, signcolumn = "no" } },
+    input = {
+      keys = {
+        ["<CR>"] = { "scratch_open", mode = { "n", "i" } },
+        ["<c-x>"] = { "scratch_delete", mode = { "n", "i" } },
+        ["<c-n>"] = { "scratch_new", mode = { "n", "i" } },
+      },
+    },
+  },
+  actions = {
+    scratch_open = function(picker)
+      local current = picker:current().file
+      picker:close()
+      Snacks.scratch.open({ file = current })
+    end,
+    scratch_delete = function(picker)
+      local current = picker:current().file
+      os.remove(current)
+      picker:close()
+      Snacks.picker.scratch()
+    end,
+    scratch_new = function(picker)
+      picker:close()
+      Snacks.scratch.open()
+    end,
+  },
+}
+
 return M

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -843,6 +843,7 @@ M.scratch = {
         ["<CR>"] = { "scratch_open", mode = { "n", "i" } },
         ["<c-x>"] = { "scratch_delete", mode = { "n", "i" } },
         ["<c-n>"] = { "scratch_new", mode = { "n", "i" } },
+        ["<c-g>"] = { "scratch_grep", mode = { "n", "i" } },
       },
     },
   },
@@ -861,6 +862,30 @@ M.scratch = {
     scratch_new = function(picker)
       picker:close()
       Snacks.scratch.open()
+    end,
+    scratch_grep = function(picker)
+      picker:close()
+      Snacks.picker.grep({
+        cwd = vim.fn.stdpath("data") .. "/scratch",
+        win = {
+          input = {
+            keys = {
+              ["<CR>"] = {
+                "open_scratch",
+                desc = "Open Scratch",
+                mode = { "n", "i" },
+              },
+            },
+          },
+        },
+        actions = {
+          ["open_scratch"] = function(picker)
+            local current = picker:current()._path
+            picker:close()
+            Snacks.scratch.open({ file = current })
+          end,
+        },
+      })
     end,
   },
 }

--- a/lua/snacks/picker/source/files.lua
+++ b/lua/snacks/picker/source/files.lua
@@ -177,4 +177,21 @@ function M.zoxide(opts, ctx)
   }, ctx)
 end
 
+---@param opts snacks.picker.proc.Config
+---@type snacks.picker.finder
+function M.scratch(opts, ctx)
+  local root = vim.fn.stdpath("data") .. "/scratch"
+  return require("snacks.picker.source.proc").proc({
+    opts,
+    {
+      cmd = "fd",
+      args = { ".", root },
+      ---@param item snacks.picker.finder.Item
+      transform = function(item)
+        item.file = item.text
+      end,
+    },
+  }, ctx)
+end
+
 return M


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
The scratch module uses `vim.ui.select` which misses the nice things about the picker.
This implementation adds scratch picker with ability to create, grep and delete scratch buffers. 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

