### PR TITLE
fix(picker.zoxide): directory icon

### DIFF
--- a/lua/snacks/picker/source/files.lua
+++ b/lua/snacks/picker/source/files.lua
@@ -172,6 +172,7 @@ function M.zoxide(opts, ctx)
       ---@param item snacks.picker.finder.Item
       transform = function(item)
         item.file = item.text
+        item.dir = true
       end,
     },
   }, ctx)


### PR DESCRIPTION
## Description

Fix the icon for `Snacks.picker.zoxide()`.

## Related Issue(s)

None.

## Screenshots

Before:

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/1c0fd481-eaa7-4bcd-8a1c-a45df35c512e" />

After:

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/b67d135d-350b-462b-b630-7801063295ac" />