### PR TITLE
feat(picker.command_history): modify commad before executing

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -144,6 +144,19 @@ M.command_history = {
   },
   confirm = "cmd",
   formatters = { text = { ft = "vim" } },
+  win = {
+    input = {
+      keys = {
+        ["<c-y>"] = { "accept_completion", mode = { "n", "i" } },
+      },
+    },
+  },
+  actions = {
+    accept_completion = function(picker)
+      local current = picker:current().cmd
+      picker.input:set(current)
+    end,
+  },
 }
 
 -- Neovim commands


### PR DESCRIPTION

## Description

Currently, there is no way to modify selected command before executing. 
This PR adds keybind to accept the current selected item as completion so commands can be manipulated before executing. 

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/folke/snacks.nvim/discussions/929

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

