### PR TITLE
fix(gitbrowse): cwd for permalinks

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -155,8 +155,10 @@ function M._open(opts)
   }
 
   if opts.what == "permalink" then
-    fields.commit =
-      system({ "git", "log", "-n", "1", "--pretty=format:%H", "--", file }, "Failed to get latest commit of file")[1]
+    fields.commit = system(
+      { "git", "-C", cwd, "log", "-n", "1", "--pretty=format:%H", "--", file },
+      "Failed to get latest commit of file"
+    )[1]
   else
     local word = vim.fn.expand("<cword>")
     fields.commit = is_valid_commit_hash(word, cwd) and word or nil


### PR DESCRIPTION
## Description

`Snacks.gitbrowse({ what = "permalink" })` got following error when `vim.fn.getcwd()` is not a git repository or not the git repository of current file:

```
E5108: Error executing lua ...cal/share/nvim/lazy/snacks.nvim/lua/snacks/gitbrowse.lua:137: ...cal/share/nvim/lazy/snacks.nvim/lua/snacks/gitbrowse.lua:117: __ignore__
stack traceback:
	[C]: in function 'error'
	...cal/share/nvim/lazy/snacks.nvim/lua/snacks/gitbrowse.lua:137: in function 'gitbrowse'
	[string ":lua"]:1: in main chunk
                         Failed to get latest commit of file
fatal: not a git repository (or any of the parent directories): .git
```

## Related Issue(s)

  - Fixes #320
  - Related #438

## Screenshots

None.
