### PR TITLE
Correct command to open buffer in new tab

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -154,7 +154,7 @@ M.confirm = M.jump -- default confirm action
 
 M.split = { action = "confirm", cmd = "split" }
 M.vsplit = { action = "confirm", cmd = "vsplit" }
-M.tab = { action = "confirm", cmd = "tab" }
+M.tab = { action = "confirm", cmd = "tabnew" }
 M.drop = { action = "confirm", cmd = "drop" }
 M.tabdrop = { action = "confirm", cmd = "tabdrop" }
 


### PR DESCRIPTION
## Description
The correct command to open a buffer in a new tab is "tabnew". The current version of the file causes a crash when attempting to use M.tab or M.edit_tab

## Related Issue(s)
  - Fixes [#1005](https://github.com/folke/snacks.nvim/issues/1005)


## Screenshots
N/A
