### PR TITLE
fix(statuscolumn): only execute `za` when fold exists

### DIFF
--- a/lua/snacks/statuscolumn.lua
+++ b/lua/snacks/statuscolumn.lua
@@ -264,7 +264,9 @@ function M.click_fold()
   local pos = vim.fn.getmousepos()
   vim.api.nvim_win_set_cursor(pos.winid, { pos.line, 1 })
   vim.api.nvim_win_call(pos.winid, function()
-    vim.cmd("normal! za")
+    if vim.fn.foldlevel(pos.line) > 0 then
+      vim.cmd("normal! za")
+    end
   end)
 end
 


### PR DESCRIPTION
## Description

Currently, clicking the status column on a line without a fold results in an error (see screenshot below). This PR adds a check before executing `za` to prevent this issue.

## Screenshots
![statuscolumn](https://github.com/user-attachments/assets/c0377595-cdcc-438c-bd3f-2feabb3a220a)

