### PR TITLE
feat(treesitter): add `tree` boolean to toggle on/off tree symbols

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -789,9 +789,11 @@ M.spelling = {
 
 ---@class snacks.picker.treesitter.Config: snacks.picker.Config
 ---@field filter table<string, string[]|boolean>? symbol kind filter
+---@field tree? boolean show symbol tree
 M.treesitter = {
   finder = "treesitter_symbols",
   format = "lsp_symbol",
+  tree = true,
   filter = {
     default = {
       "Class",

--- a/lua/snacks/picker/source/treesitter.lua
+++ b/lua/snacks/picker/source/treesitter.lua
@@ -149,7 +149,7 @@ function M.symbols(opts, ctx)
       item = {
         text = match.text,
         depth = depth or 0,
-        tree = true,
+        tree = opts.tree,
         buf = buf,
         name = match.text,
         kind = kind_mapping[match.kind] or "Unknown",


### PR DESCRIPTION
## Description
Adds a `opts.tree` boolean option for treesitter picker to toggle on/off tree symbols
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None, rather a discussion #1101
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

