### PR TITLE
feat(picker): add LSP symbol range to result item

### DIFF
--- a/lua/snacks/picker/source/lsp/init.lua
+++ b/lua/snacks/picker/source/lsp/init.lua
@@ -260,6 +260,7 @@ function M.results_to_items(client, results, opts)
       detail = result.detail,
       name = result.name,
       text = "",
+      range = result.range,
     }
     local uri = result.location and result.location.uri or result.uri or opts.default_uri
     local loc = result.location or { range = result.selectionRange or result.range, uri = uri }


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

this adds an attribute for the range of the LSP symbol to each picker item.

## Related Issue(s)

Fixes #1057 

having access to the range of the LSP symbol (i.e. the whole context of classes and methods) would be tremendously helpful for my solution in https://github.com/folke/snacks.nvim/issues/1057#issuecomment-2652052218. Currently the picker items only have a `loc` attribute which holds the range of the symbol identifier, i.e. the class/method name.

---

perhaps in a followup we could use the range to highlight the symbol context, similar to how trouble.nvim does it

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

