### PR TITLE
fix(gitbrowse): previous logic always overwrote 'commit'

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -186,10 +186,10 @@ function M._open(opts)
   if not fields.commit and (opts.what == "commit" or opts.what == "permalink") then
     opts.what = "file"
   end
-  if not fields.file then
+  if not fields.commit and not fields.file then
     opts.what = "branch"
   end
-  if not fields.branch then
+  if not fields.commit and not fields.branch then
     opts.what = "repo"
   end
 


### PR DESCRIPTION
## Description
The previous logic didn't check for `fields.commit` when checking whether to switch to `branch` or `repo`, thus `opts.what = "commit"` was always being overwritten.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

