### PR TITLE
fix(picker.help): don't load plugin if file in `VIMRUNTIME`

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -526,7 +526,7 @@ function M.help(picker, item, action)
   if item then
     picker:close()
     local file = Snacks.picker.util.path(item) or ""
-    if package.loaded.lazy then
+    if package.loaded.lazy and not vim.startswith(file, vim.env.VIMRUNTIME) then
       local plugin = file:match("/([^/]+)/doc/")
       if plugin then
         require("lazy").load({ plugins = { plugin } })


### PR DESCRIPTION
## Description
Currently, when you open a help item that is in `VIMRUNTIME`, you get an error `Plugin runtime not found`. 

Only load plugin when `file` does not include `VIMRUNTIME` in its path.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

