### PR TITLE
fix(picker.explorer): ensure diagnostics can be disabled

### DIFF
--- a/lua/snacks/picker/source/explorer.lua
+++ b/lua/snacks/picker/source/explorer.lua
@@ -71,14 +71,16 @@ function State.new(picker)
     end
   end)
 
-  picker.list.win:on("DiagnosticChanged", function(_, ev)
-    local p = ref()
-    if p then
-      require("snacks.explorer.diagnostics").update(p:cwd())
-      p.list:set_target()
-      p:find()
-    end
-  end)
+  if opts.diagnostics then
+    picker.list.win:on("DiagnosticChanged", function(_, ev)
+      local p = ref()
+      if p then
+        require("snacks.explorer.diagnostics").update(p:cwd())
+        p.list:set_target()
+        p:find()
+      end
+    end)
+  end
 
   -- schedule initial follow
   if opts.follow_file then


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

`opts.diagnostics=false` was being ignored by `Snacks.picker.explorer`

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

I didn't create an issue for it

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
