### PR TITLE
fix(input): add missing hl group for input title

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -151,7 +151,7 @@ function M.input(opts, on_confirm)
   add(opts.prompt, "SnacksInputTitle", opts.prompt_pos)
 
   if next(title) then
-    table.insert(title, { " " })
+    table.insert(title, { " ", "SnacksInputTitle" })
   end
 
   ---@param text? string


### PR DESCRIPTION
Add the missing highlight group for input title.
Before:
![image](https://github.com/user-attachments/assets/600c8886-0547-48f5-b878-5d0482537446)
After:
![image](https://github.com/user-attachments/assets/13bad24f-6f96-41d6-ab3a-0b9001f68ea9)
