### PR TITLE
feat(picker.lsp): add new option `lsp_result_transform`

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -539,6 +539,7 @@ M.lsp_references = {
 ---@field tree? boolean show symbol tree
 ---@field filter table<string, string[]|boolean>? symbol kind filter
 ---@field workspace? boolean show workspace symbols
+---@field lsp_result_transform? (fun(result:lsp.ResultItem, item:snacks.picker.finder.Item):snacks.picker.finder.Item) custom LSP result transformer
 M.lsp_symbols = {
   finder = "lsp_symbols",
   format = "lsp_symbol",

--- a/lua/snacks/picker/source/lsp/init.lua
+++ b/lua/snacks/picker/source/lsp/init.lua
@@ -244,7 +244,7 @@ end
 ---@alias lsp.ResultItem lsp.Symbol|lsp.CallHierarchyItem|{text?:string}
 ---@param client vim.lsp.Client
 ---@param results lsp.ResultItem[]
----@param opts? {default_uri?:string, filter?:(fun(result:lsp.ResultItem):boolean), text_with_file?:boolean}
+---@param opts? {default_uri?:string, filter?:(fun(result:lsp.ResultItem):boolean), text_with_file?:boolean, transformer?:(fun(result:lsp.ResultItem, item:snacks.picker.finder.Item):snacks.picker.finder.Item)}
 function M.results_to_items(client, results, opts)
   opts = opts or {}
   local items = {} ---@type snacks.picker.finder.Item[]
@@ -271,6 +271,10 @@ function M.results_to_items(client, results, opts)
       text = text .. " " .. item.file
     end
     item.text = text
+
+    if opts.transformer and type(opts.transformer) == "function" then
+      item = opts.transformer(result, item)
+    end
 
     if not opts.filter or opts.filter(result) then
       items[#items + 1] = item
@@ -354,6 +358,7 @@ function M.symbols(opts, ctx)
         filter = function(item)
           return want(M.symbol_kind(item.kind))
         end,
+        transformer = opts.lsp_result_transform,
       })
 
       -- Fix sorting


### PR DESCRIPTION
## Description

To extend the functionality of the picker for processing LSP symbols, I added the `lsp_result_transform` option, which allows further modification of picker items with results returned by LSP.

I created a example with this option, see: https://github.com/fang2hou/go-impl.nvim/pull/1.

In the above case, the Go Language Server `gopls` returns a `containerName` field that indicates the package where the symbol is located. Currently, if I want to retrieve the package name of a symbol, I need to clone the built-in snacks finder function and make a slight modification to include the `containerName` field during post-processing.

Since many LSPs return custom fields based on their own language specifications, variations like this may quite common. Adding an option makes it easier for plugin authors to integrate with the snacks.picker without worrying about differences between the built-in `lsp_symbols` finder and a cloned version.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

