### PR TITLE
feat(picker.explorer): support custom icon for open directory

### DIFF
--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -504,6 +504,7 @@ below.
           vertical = "│ ",
           middle   = "├╴",
           last     = "└╴",
+          open_dir = "󰝰 ",
         },
         undo = {
           saved   = " ",

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -324,6 +324,7 @@ Snacks.picker.pick({source = "files", ...})
       vertical = "│ ",
       middle   = "├╴",
       last     = "└╴",
+      open_dir = "󰝰 ",
     },
     undo = {
       saved   = " ",

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -321,6 +321,7 @@ local defaults = {
       vertical = "│ ",
       middle   = "├╴",
       last     = "└╴",
+      open_dir = "󰝰 ",
     },
     undo = {
       saved   = " ",

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -59,7 +59,7 @@ function M.filename(item, picker)
   if picker.opts.icons.files.enabled ~= false then
     local icon, hl = Snacks.util.icon(name, cat)
     if item.dir and item.open then
-      icon = " "
+      icon = picker.opts.icons.tree.open_dir or " "
     end
     icon = Snacks.picker.util.align(icon, picker.opts.formatters.file.icon_width or 2)
     ret[#ret + 1] = { icon, hl, virtual = true }

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -59,7 +59,7 @@ function M.filename(item, picker)
   if picker.opts.icons.files.enabled ~= false then
     local icon, hl = Snacks.util.icon(name, cat)
     if item.dir and item.open then
-      icon = picker.opts.icons.tree.open_dir or " "
+      icon = picker.opts.icons.tree.open_dir
     end
     icon = Snacks.picker.util.align(icon, picker.opts.formatters.file.icon_width or 2)
     ret[#ret + 1] = { icon, hl, virtual = true }


### PR DESCRIPTION
## Description

The icon used for open directories in explorer picker  is hardcoded to a folder icon from the fontawesome library (nerdfont name: `nf-fa-*`) but the ones generally used by `mini.icons` are from material design (nerdfont name: `nf-md-*`). 

This PR adds support for custom icon for open directories and sets the default open directory icon to that provided my material design.

## Screenshots
Before:
![Screenshot 2025-02-15 at 7 58 46 PM](https://github.com/user-attachments/assets/5b1d76bd-c5c4-4670-a0b2-5a7aabe0f3ab)
After:
![Screenshot 2025-02-15 at 8 00 32 PM](https://github.com/user-attachments/assets/4fece481-94e2-43a9-a250-2385e1f37b8a)


