### PR TITLE
fix(filter): Fix filtering condition check

### DIFF
--- a/lua/snacks/picker/core/filter.lua
+++ b/lua/snacks/picker/core/filter.lua
@@ -101,8 +101,8 @@ function M:match(item)
   end
   if self.opts.paths then
     for _, p in ipairs(self.paths) do
-      if (path:sub(1, #p.path) == p.path) ~= p.want then
-        return false
+      if path:find("^" .. p.path) then
+        return p.want
       end
     end
   end


### PR DESCRIPTION
Check the boolean field of the filter path only when there is a direct
match. Otherwise a filter's path boolean value that is true dominates
the results.

Example:

```lua
opts = {
  sources = {
    recent =  {
      filter = {
        paths = {
          [vim.fn.stdpath("data")] = true,
        }
      }
    }
  }
}
```

This would cause the recent picker to only include paths from the
stdpath("data"). Since the previous condition could never allow any
other path to return true.

But I merely want to enable that path to be included in the results.