### PR TITLE
fix(picker.git): preserve chronological order when matching

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -270,6 +270,7 @@ M.git_log = {
   format = "git_log",
   preview = "git_show",
   confirm = "git_checkout",
+  sort = { fields = { "score:desc", "idx" } },
 }
 
 ---@type snacks.picker.git.log.Config
@@ -280,6 +281,7 @@ M.git_log_file = {
   current_file = true,
   follow = true,
   confirm = "git_checkout",
+  sort = { fields = { "score:desc", "idx" } },
 }
 
 ---@type snacks.picker.git.log.Config
@@ -290,6 +292,7 @@ M.git_log_line = {
   current_line = true,
   follow = true,
   confirm = "git_checkout",
+  sort = { fields = { "score:desc", "idx" } },
 }
 
 M.git_stash = {


### PR DESCRIPTION
## Description

When using the git log sources, what are your thoughts on preserving the sort order when matching? I find most often when I use this picker I want to see results in reverse chronological order. For example, I like to use the picker to review the commit log to see new features added to a repo.

## Screenshots

When matching for `feat` in the snacks repo with current behavior, the output is less than useful:
<img width="868" alt="image" src="https://github.com/user-attachments/assets/ed0fdf2a-ee1f-4325-8c87-85911837a757" />

But with the proposed change, it's much more relevant:
<img width="868" alt="image" src="https://github.com/user-attachments/assets/7052b353-d38d-4573-bf72-b0d99c21672d" />

## Alternatives

I can override in my config:

```lua
      picker = {
        sources = {
          git_log = { sort = { fields = { "score:desc", "idx" } } },
          git_log_file = { sort = { fields = { "score:desc", "idx" } } },
          git_log_line = { sort = { fields = { "score:desc", "idx" } } },
        },
      },
```