### PR TITLE
perf(dashboard): speed up filtering for recent_files

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -796,9 +796,10 @@ function M.oldfiles(opts)
   end
   local done = {} ---@type table<string, boolean>
   local i = 1
+  local oldfiles = vim.v.oldfiles
   return function()
-    while vim.v.oldfiles[i] do
-      local file = vim.fs.normalize(vim.v.oldfiles[i], { _fast = true, expand_env = false })
+    while oldfiles[i] do
+      local file = vim.fs.normalize(oldfiles[i], { _fast = true, expand_env = false })
       local want = not done[file]
       if want then
         done[file] = true

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -795,10 +795,9 @@ function M.oldfiles(opts)
     table.insert(filter, { path = vim.fs.normalize(path), want = want })
   end
   local done = {} ---@type table<string, boolean>
-  local i = 1
   return function()
-    while vim.v.oldfiles[i] do
-      local file = vim.fs.normalize(vim.v.oldfiles[i], { _fast = true, expand_env = false })
+    for _, oldfile in ipairs(vim.v.oldfiles) do
+      local file = vim.fs.normalize(oldfile, { _fast = true, expand_env = false })
       local want = not done[file]
       if want then
         done[file] = true
@@ -809,7 +808,6 @@ function M.oldfiles(opts)
           end
         end
       end
-      i = i + 1
       if want and uv.fs_stat(file) then
         return file
       end

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -795,9 +795,10 @@ function M.oldfiles(opts)
     table.insert(filter, { path = vim.fs.normalize(path), want = want })
   end
   local done = {} ---@type table<string, boolean>
+  local i = 1
   return function()
-    for _, oldfile in ipairs(vim.v.oldfiles) do
-      local file = vim.fs.normalize(oldfile, { _fast = true, expand_env = false })
+    while vim.v.oldfiles[i] do
+      local file = vim.fs.normalize(vim.v.oldfiles[i], { _fast = true, expand_env = false })
       local want = not done[file]
       if want then
         done[file] = true
@@ -808,6 +809,7 @@ function M.oldfiles(opts)
           end
         end
       end
+      i = i + 1
       if want and uv.fs_stat(file) then
         return file
       end


### PR DESCRIPTION
## Description

I have 5000 oldfiles, every time i go to a new directory and open nvim, the dashboard recent_files (with `cwd=true`) computation takes 4-5 seconds to go through all oldfiles before deciding nothing should show up

```lua
sections = {
  { icon = " ", title = "Recent files (current directory)", section = "recent_files", cwd = true },
}
```

It appears to be the `vim.v.oldfiles[i]` indexing. I didn't look much into it but it opens much faster looping with ipairs.

Repro:
1. add the above section config in dashboard
2. increase oldfiles limit and populate up to the limit
3. `mkdir brand-new-directory; cd brand-new-directory; nvim`
4. the section is empty as expected, but it takes a few seconds before dashboard shows up

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

