### PR TITLE
feat(dashboard): opening dashboard to extension

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -48,7 +48,6 @@ math.randomseed(os.time())
 ---@alias snacks.dashboard.Section snacks.dashboard.Item|snacks.dashboard.Gen|snacks.dashboard.Section[]
 
 ---@class snacks.dashboard.Format
----@field hl? string
 ---@field priority? number determines order in which format will be checked
 ---@field align? "left" | "center" | "right"
 ---@field format snacks.dashboard.Format.function
@@ -364,9 +363,7 @@ function D:format_field(item, field, width)
   elseif type(format) == "function" then
     return format(item, { width = width, dashboard = self })
   elseif type(format) == "table" and type(format.format) == "function" then
-    local result = format.format(item, { width = width, dashboard = self })
-    result.hl = result.hl or format.hl or field
-    return result
+    return format.format(item, { width = width, dashboard = self })
   else
     local text = format and vim.deepcopy(format) or { "%s" }
     text.hl = text.hl or field


### PR DESCRIPTION
adds 'templates' and 'extensions' to dashboard config templates: table of functions that build sections
  - the 'built-in' sections are considered templates extensions: array of collections of templates and formats
  - intention is for a low-hassle way to include templates and formats from plugins

formats will now respect custom format fields, and not just custom formats over the built-in fields

## Description

A good-faith attempt to make extending the Dashboard more convenient.
Constructive feedback and changes are welcome.

The overall goal: 
- Develop plugins that can provide new dashboard behaviors
- Users able to apply plugin behavior to the dashboard with minimal effort
- Prefer a declarative approach

This is accomplished with the following:
- A `templates` table is added to configuration
    - By default, populated with all of the 'built-in sections'
    - Users may add more templates
    - Previous capabilities would require users to alter the modules' `sections` table to add new 'built-in sections'.  This probably wasn't recommended, either.
- The `formats` table will now support arbitrary field names
    - Previous format support only permitted changing the built-in formats / fields
- Formats as functions can now be passed as a table with an `align` value, and a `priority` value.
    - align='left' will act as icon formats
    - align='right' will act as key/label formats
- The `opts` table of format functions now also provides the dashboard instance, under the name `dashboard`
    - This can permit a format to call another format and modify its results
- An `extensions` array is added to configuration, to support single-line plugin extension
    - Array of either tables, or functions that return tables
    - Provides new templates and formats
- e.g.

```
  {
    extensions = {
      {
        templates = {
          hello_world = function(item)
            if type(item.planet) == 'string' then
              return { greeting = 'Hello ' .. item.planet }
            else
              return { greeting = 'Hello World' }
            end
          end
        },
        formats = {
          greeting = function(item, opts)
            return { item.greeting, hl = 'markdownH5' }
          end
        }
      },
    },
    sections = {
      { section = 'header' },
      { section = 'hello_world', planet = 'Moon' },
      { section = 'hello_world', planet = 'Sun' },
    }
  }
```

- However, the more intended way to use extensions would be as below:

```
  {
    extensions = {
      function() return require('hello-world-dashboard').extension end
    },
    sections = {
      { section = 'header' },
      { section = 'hello_world', planet = 'Moon' },
      { section = 'hello_world', planet = 'Sun' },
    }
  }
```

- Users developing local templates or formats would be expected to use `templates` and the existing `formats` tables
- Users loading templates and formats from plugins would be expected to use the `extensions` array


## Related Issue(s)


## Screenshots

Hello world demo
![{D33F4F38-3185-4FDE-90AF-0636402A24D1}](https://github.com/user-attachments/assets/aeda24c8-669e-49aa-86cd-145ba360508f)

