### PR TITLE
feat(image): add support for `svelte`

### DIFF
--- a/doc/snacks-image.txt
+++ b/doc/snacks-image.txt
@@ -24,7 +24,7 @@ Table of Contents                             *snacks-image-table-of-contents*
 - open images in a wide range of formats:
     `png`, `jpg`, `jpeg`, `gif`, `bmp`, `webp`, `tiff`, `heic`, `avif`, `mp4`, `mov`, `avi`, `mkv`, `webm`
 - Supports inline image rendering in:
-    `markdown`, `html`, `norg`, `tsx`, `javascript`, `css`, `vue`, `scss`, `latex`, `typst`, `vue`
+    `markdown`, `html`, `norg`, `tsx`, `javascript`, `css`, `vue`, `svelte`, `scss`, `latex`, `typst`
 - LaTex math expressions in `markdown` and `latex` documents
 
 Terminal support:

--- a/docs/image.md
+++ b/docs/image.md
@@ -8,7 +8,7 @@
 - open images in a wide range of formats:
   `pdf`, `png`, `jpg`, `jpeg`, `gif`, `bmp`, `webp`, `tiff`, `heic`, `avif`, `mp4`, `mov`, `avi`, `mkv`, `webm`
 - Supports inline image rendering in:
-  `markdown`, `html`, `norg`, `tsx`, `javascript`, `css`, `vue`, `scss`, `latex`, `typst`, `vue`
+  `markdown`, `html`, `norg`, `tsx`, `javascript`, `css`, `vue`, `svelte`, `scss`, `latex`, `typst`
 - LaTex math expressions in `markdown` and `latex` documents
 
 Terminal support:

--- a/queries/svelte/images.scm
+++ b/queries/svelte/images.scm
@@ -1,0 +1,2 @@
+; inherits: html
+; extends

--- a/tests/image/test.svelte
+++ b/tests/image/test.svelte
@@ -1,0 +1,14 @@
+<script>
+  const greeting = "hello";
+</script>
+
+<p class="greeting">{greeting}</p>
+<img src="test.png" alt="test" />
+
+<style>
+  .greeting {
+    color: red;
+    font-weight: bold;
+    background: url("test.png");
+  }
+</style>


### PR DESCRIPTION
## Description

Added queries for Svelte as well, based on Vue.

Note that I am not sure if the current HTML queries, which both Vue and this Svelt query inherits from, is working as intended.

I do not get any sort of inline images. But I guess that will have to be debugged and fixed in another issue and the fix should not affect this patch (hopefully).

## Related Issue(s)

Fixes #1275 