### PR TITLE
fix(picker.actions): `search` action correctly treat `<`

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -495,7 +495,7 @@ end
 function M.search(picker, item)
   picker:close()
   if item then
-    vim.api.nvim_input("/" .. item.text)
+    vim.api.nvim_input("/" .. item.text:gsub("<", "<lt>"))
   end
 end
 


### PR DESCRIPTION
## Description
`nvim_input` treats `<` character as special, so pass `<lt>` for literal `<` if found in `item.text`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
#1291 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

