### PR TITLE
feat(words): add `filter` function for user to disable specific filetypes

### DIFF
--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -18,6 +18,7 @@ local defaults = {
   foldopen = true, -- open folds after jumping
   jumplist = true, -- set jump point before jumping
   modes = { "n", "i", "c" }, -- modes to show references
+  exclude_ft = {}, -- filetypes to exclude
 }
 
 M.enabled = false
@@ -95,6 +96,13 @@ function M.is_enabled(opts)
     mode = mode:sub(1, 2) == "no" and "o" or mode
     mode = mode:sub(1, 1):match("[ncitsvo]") or "n"
     if not vim.tbl_contains(config.modes, mode) then
+      return false
+    end
+  end
+
+  if not vim.tbl_isempty(config.exclude_ft) then
+    local ft = vim.bo[vim.api.nvim_get_current_buf()].filetype
+    if vim.tbl_contains(config.exclude_ft, ft) then
       return false
     end
   end

--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -18,7 +18,9 @@ local defaults = {
   foldopen = true, -- open folds after jumping
   jumplist = true, -- set jump point before jumping
   modes = { "n", "i", "c" }, -- modes to show references
-  exclude_ft = {}, -- filetypes to exclude
+  filter = function(buf) -- what buffers to enable `snacks.words`
+    return vim.g.snacks_words ~= false and vim.b[buf].snacks_words ~= false
+  end,
 }
 
 M.enabled = false
@@ -100,14 +102,10 @@ function M.is_enabled(opts)
     end
   end
 
-  if not vim.tbl_isempty(config.exclude_ft) then
-    local ft = vim.bo[vim.api.nvim_get_current_buf()].filetype
-    if vim.tbl_contains(config.exclude_ft, ft) then
-      return false
-    end
-  end
-
   local buf = opts.buf or vim.api.nvim_get_current_buf()
+  if not config.filter(buf) then
+    return false
+  end
   local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = buf })
   clients = vim.tbl_filter(function(client)
     return client.supports_method("textDocument/documentHighlight", { bufnr = buf })


### PR DESCRIPTION
## Description
This allows user to specify explicitly filetypes to disable `snacks.words`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #1294 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

