### PR TITLE
feat(image): add `Snacks.image.hover_inline()` function

### DIFF
--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -170,6 +170,19 @@ function M.hover()
   M.doc.hover()
 end
 
+local bufs = {}
+
+--- Show the image inline
+function M.hover_inline()
+  local buf = vim.api.nvim_get_current_buf()
+  if not bufs[buf] then
+    bufs[buf] = M.doc.hover_inline(buf)
+    bufs[buf]()
+  else
+    bufs[buf]()
+  end
+end
+
 ---@return string[]
 function M.langs()
   local queries = vim.api.nvim_get_runtime_file("queries/*/images.scm", true)


### PR DESCRIPTION
## Description

https://github.com/folke/snacks.nvim/issues/1258#issuecomment-2665210723

When `inline = true` there are too many images, `Snacks.image.hover()` does not persist for afterwards reference.

## Screenshots

[Screencast_20250219_113101.webm](https://github.com/user-attachments/assets/44fef140-930d-4e03-b227-231e6465b74e)


