### PR TITLE
fix(image.doc): crop inline typst equations properly

### DIFF
--- a/lua/snacks/image/doc.lua
+++ b/lua/snacks/image/doc.lua
@@ -25,6 +25,7 @@ M.transforms = {
     local fg = Snacks.util.color("SnacksImageMath") or "#000000"
     img.content = ([[
 #set page(width: auto, height: auto, margin: (x: 2pt, y: 2pt))
+#show math.equation.where(block: false): set text(top-edge: "bounds", bottom-edge: "bounds")
 #set text(size: 12pt, fill: rgb("%s"))
 %s
 %s]]):format(fg, M.get_header(ctx.buf), img.content)


### PR DESCRIPTION
## Description

Tall inline typst equations were previously cropped too much vertically. The change to the template now resize text frames to the bounding box of their glyphs. See https://typst.app/docs/reference/text/text/#parameters-top-edge for more details.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/15ea02e2-7d10-43bb-8d4f-fc51013c8a20)
After:
![image](https://github.com/user-attachments/assets/70de42d9-4b29-4333-a908-6be4729baa8a)


