### PR TITLE
feat(image): add `Snacks.image.hover_inline()` function

### DIFF
--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -181,6 +181,19 @@ function M.hover()
   M.doc.hover()
 end
 
+local bufs = {}
+
+--- Show the image inline
+function M.hover_inline()
+  local buf = vim.api.nvim_get_current_buf()
+  if not bufs[buf] then
+    bufs[buf] = M.doc.hover_inline(buf)
+    bufs[buf]()
+  else
+    bufs[buf]()
+  end
+end
+
 ---@return string[]
 function M.langs()
   local queries = vim.api.nvim_get_runtime_file("queries/*/images.scm", true)


### PR DESCRIPTION
## Description

reopen https://github.com/folke/snacks.nvim/pull/1298

## Screenshots

[Screencast_20250220_124824.webm](https://github.com/user-attachments/assets/2fc6f23d-c4ee-44d7-80a7-76bbbc57f0a3)

```lua
return {
	{
		"yuukibarns/snacks.nvim",
		branch = "test",
		lazy = false,
		priority = 1000,
		keys = {
			{
				"K",
				ft = { "tex", "markdown" },
				function()
					Snacks.image.hover_inline()
				end,
				desc = "Preview math formula under cursor inline"
			}
		},
		---@type snacks.Config
		opts = {
			image = {
				enabled = true,
				doc = {
					-- enable image viewer for documents
					-- a treesitter parser must be available for the enabled languages.
					-- supported language injections: markdown, html
					enabled = true,
					-- render the image inline in the buffer
					-- if your env doesn't support unicode placeholders, this will be disabled
					-- takes precedence over `opts.float` on supported terminals
					inline = false,
					-- render the image in a floating window
					-- only used if `opts.inline` is disabled
					float = false,
					max_width = 80,
					max_height = 40,
				},
				convert = {
					notify = true, -- show a notification on error
					math = {
						font_size = "small", -- see https://www.sascha-frank.com/latex-font-size.html
						-- for latex documents, the doc packages are included automatically,
						-- but you can add more packages here. Useful for markdown documents.
						packages = { "amsmath", "amssymb", "amsfonts", "amscd", "mathtools", "tikz-cd" },
					},
					---@type snacks.image.args
					mermaid = function()
						local theme = vim.o.background == "light" and "neutral" or "dark"
						return { "-i", "{src}", "-o", "{file}", "-b", "transparent", "-t", theme, "-s", "{scale}" }
					end,
					---@type table<string,snacks.image.args>
					magick = {
						default = { "{src}[0]", "-scale", "1920x1080>" }, -- default for raster images
						vector = { "-density", 192, "{src}[0]" }, -- used by vector images like svg
						math = { "-density", 192, "{src}[0]", "-resize", "150%", "-trim" },
						pdf = { "-density", 192, "{src}[0]", "-background", "white", "-alpha", "remove", "-trim" },
					},
				}
			}
		}
	}
}
```

## Bug

As you may see,  in the end of video, if there are some changes to the lines above the image that changes the position of the image then the image will be closed, for I use position and source to identify images.
