### PR TITLE
Allow debug evaluation of block selections

### DIFF
--- a/lua/snacks/debug.lua
+++ b/lua/snacks/debug.lua
@@ -98,6 +98,21 @@ function M.run(opts)
       table.insert(lines, 1, "")
     end
     vim.fn.feedkeys("gv", "nx")
+  elseif mode == "\22" then
+    -- Yank the visual selection to handle irregularly shaped blocks
+    local tmp = vim.fn.getreginfo("*")
+    vim.cmd('normal! "*y')
+    lines = vim.fn.getreginfo("*").regcontents
+    vim.fn.setreg("*", tmp.regcontents, tmp.regtype)
+
+    -- Insert empty lines to keep the line numbers
+    local from = vim.api.nvim_buf_get_mark(buf, "<")
+    for _ = 1, from[1] - 1 do
+      table.insert(lines, 1, "")
+    end
+
+    -- Restore the selection
+    vim.fn.feedkeys("gv", "nx")
   else
     lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   end


### PR DESCRIPTION
## Description

This PR adds basic support for visual block selections to `Snacks.debug.run()`. This is useful when code doesn't start at the beginning of a line, such as in comment blocks.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
<img width="271" alt="Screenshot 2025-02-19 at 23 02 35" src="https://github.com/user-attachments/assets/5a440b32-6846-4345-b105-42e64796ac65" />