### PR TITLE
feat(gitbrowse): get commit hash from current line on open

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -170,7 +170,7 @@ function M._open(opts)
     local word = vim.fn.expand("<cword>")
     fields.commit = is_valid_commit_hash(word, cwd) and word or nil
 
-    if not fields.commit then
+    if not fields.commit and not vim.fn.mode():find("[vV]") then
       local line_number = vim.fn.line('.')
       local blame_output = vim.fn.system(string.format("git blame -L %d,%d %s", line_number, line_number, file))
       local commit_hash = blame_output:match("^(%w+)")

--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -169,6 +169,13 @@ function M._open(opts)
   else
     local word = vim.fn.expand("<cword>")
     fields.commit = is_valid_commit_hash(word, cwd) and word or nil
+
+    if not fields.commit then
+      local line_number = vim.fn.line('.')
+      local blame_output = vim.fn.system(string.format("git blame -L %d,%d %s", line_number, line_number, file))
+      local commit_hash = blame_output:match("^(%w+)")
+      fields.commit = is_valid_commit_hash(commit_hash, cwd) and commit_hash or nil
+    end
   end
 
   -- Get visual selection range if in visual mode


### PR DESCRIPTION
## Description

Allow gitbrowse to get the current line commit hash when using `Snacks.gitbrowse.open()`

## Related Issue(s)

Currently you must hover the word of the actually commit hash. This requires you opening git blame(or something similar) and hovering the word of the commit hash you want to open.

I feel like this is kind of clunky and would it would be nicer to just be able to open commit url straight from file/line.