### PR TITLE
feat(image): fixing problem with latex rendering in kitty

### DIFF
--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -53,13 +53,13 @@ vim.api.nvim_create_autocmd("VimResized", {
 
 -- HACK: ghostty doesn't like it when sending images too fast,
 -- after Neovim startup, so we delay the first image
-local queue = {} ---@type string[]?
-vim.defer_fn(function()
-  if queue and #queue > 0 then
-    io.stdout:write(table.concat(queue, ""))
-  end
-  queue = nil
-end, 100)
+-- local queue = {} ---@type string[]?
+-- vim.defer_fn(function()
+--   if queue and #queue > 0 then
+--     io.stdout:write(table.concat(queue, ""))
+--   end
+--   queue = nil
+-- end, 100)
 
 function M.size()
   if size then
@@ -190,12 +190,14 @@ function M.set_cursor(pos)
   M.write("\27[" .. pos[1] .. ";" .. (pos[2] + 1) .. "H")
 end
 
+local firstWrite = true
+
 function M.write(data)
-  if queue then
-    table.insert(queue, data)
-  else
-    io.stdout:write(data)
+  if firstWrite then
+    vim.wait(100)
+    firstWrite = false
   end
+  io.stdout:write(data)
 end
 
 return M


### PR DESCRIPTION
Hi Folke,

A few days ago I reported a problem with latex rendering in kitty (bug: Latex preview #1369). you closed it quickly because you could not reproduce it, but I managed to do so every single time. Checkhealth report for Snacks on my Mac with Neovim is all green. So i decided to dig deeper into the code and in image/terminal.lua I have found the root cause of my problems.

In that file you have a hack:

 -- HACK: ghostty doesn't like it when sending images too fast,
 -- after Neovim startup, so we delay the first image

After that you queue data for 100ms, and when that period expires all buffered data is sent to stdout, buffered is deleted and after that everything goes directly to stdout. Fair enough, but that async aspect is something that kitty does not like, **like you have some kind of racing condition elsewhere.**

I tried to leave your hack as it is and to change the write function so that buffering is used only for ghostty in the following way:

```
 function M.write(data)
  if queue and M.env().name == "ghostty" then
    table.insert(queue, data)
  else
    io.stdout:write(data)
end
```

So buffering is enabled only for ghostty and for other terms writing is performed without buffering.

The situation improved immediately but in long latex documents (20+) equations I stll had an empty block here and there.

The solution that I'm submitting as a pull request is the only one that works for kitty 100% (I have spent the whole day testing) but still keeps that delay of 100ms needed by ghostty.

Basically, I ditched your buffering hack completely and modified the write function as follows.

```
local firstWrite = true

function M.write(data)
  if firstWrite then
    vim.wait(100)
    firstWrite = false
  end
  io.stdout:write(data)
end
```

Please, don't kill me for using vim.wait(100) - yes UI will be blocked for 0.1 seconds but I will personally buy a new Mac to everybody who notices that his computer was blocked for such a short time. So now everything is synchronous in terminal.lua and all problems have disappeared. Yes, it's a hack, a bit dirtier than yours, but it works.