### PR TITLE
feat(image): support reference-style images in markdown

### DIFF
--- a/lua/snacks/image/doc.lua
+++ b/lua/snacks/image/doc.lua
@@ -259,7 +259,7 @@ function M.find(buf, from, to)
 end
 
 ---@param ctx snacks.image.ctx
----@param matches snacks.image.match
+---@param matches snacks.image.match[]
 function M._img(ctx, matches)
   ctx.pos = ctx.pos or ctx.src or ctx.content or ctx.ref
   assert(ctx.pos, "no image node")

--- a/queries/markdown/link_definition.scm
+++ b/queries/markdown/link_definition.scm
@@ -1,0 +1,4 @@
+(link_reference_definition
+  (link_label) @linkDefinition.label
+  (link_destination) @linkDefinition.dest
+) @linkDefinition

--- a/queries/markdown_inline/images.scm
+++ b/queries/markdown_inline/images.scm
@@ -1,10 +1,18 @@
 
-(image 
+(image
   [
     (link_destination) @image.src
     (image_description (shortcut_link (link_text) @image.src))
   ]
-    (#gsub! @image.src "|.*" "") ; remove wikilink image options
-    (#gsub! @image.src "^<" "") ; remove bracket link
-    (#gsub! @image.src ">$" "")
-  ) @image
+  (#gsub! @image.src "|.*" "") ; remove wikilink image options
+  (#gsub! @image.src "^<" "") ; remove bracket link
+  (#gsub! @image.src ">$" "")
+) @image
+
+; Short reference style: ![ref][]
+((image
+  (image_description) @image.ref))
+
+; Full reference style: ![alt][ref]
+((image
+  (link_label) @image.ref) @image)


### PR DESCRIPTION
## Description

The image previewer in kitty like terminal is cool, but it looks like the reference-style in markdown not works, this pr is try to add the support of the reference-style image preview.


<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
#1408 

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

![image](https://github.com/user-attachments/assets/f63800ba-0f37-4863-a4c2-7a7255f4c7b0)


<!-- Add screenshots of the changes if applicable. -->

