### PR TITLE
feat(layout): configurable winhighlight options for layout's box_wins

### DIFF
--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -104,6 +104,9 @@ function M.new(opts)
           w = { snacks_layout = true },
           border = box.border,
         }))
+        if not (box.wo and box.wo.winhighlight) then
+          self.box_wins[box.id].opts.wo.winhighlight = Snacks.picker.highlight.winhl("SnacksPickerBox")
+        end
       end
     end
   end)

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -73,7 +73,7 @@ function M.get(opts)
   local ret = {} ---@type snacks.Picker[]
   for picker in pairs(M._active) do
     local want = (not opts.source or picker.opts.source == opts.source)
-      and (opts.tab == false or picker:on_current_tab())
+        and (opts.tab == false or picker:on_current_tab())
     if want then
       ret[#ret + 1] = picker
     end
@@ -270,11 +270,6 @@ function M:init_layout(layout)
   }))
   self:attach()
 
-  -- apply box highlight groups
-  local boxwhl = Snacks.picker.highlight.winhl("SnacksPickerBox")
-  for _, win in pairs(self.layout.box_wins) do
-    win.opts.wo.winhighlight = boxwhl
-  end
   return layout
 end
 


### PR DESCRIPTION
## Description

For now，the layout's config such as:

```lua
{
    layout = {
        backdrop = false,
        relative = "cursor",
        width = 0.5,
        min_width = 80,
        height = 0.4,
        min_height = 3,
        box = "vertical",
        border = "rounded",
        title = "{title}",
        title_pos = "center",
        wo = {
            winhighlight = "FloatBorder:LspWinCodeActionBorder,FloatTitle:LspWinCodeActionTitle",
        },
        {
            win = "input",
            height = 1,
            border = "bottom",
            wo = {
                winhighlight = "FloatBorder:LspWinCodeActionBorder"
            }
        },
        { win = "list",    border = "none" },
        { win = "preview", title = "{preview}", height = 0.4, border = "top" },
    },
}
```

the `layout.wo.winhighlight ` does not work for box wins.

This merge make the config above work.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

