### PR TITLE
feat(layout): configurable winhighlight options for layout's box_wins

### DIFF
--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -104,6 +104,9 @@ function M.new(opts)
           w = { snacks_layout = true },
           border = box.border,
         }))
+        if not (box.wo and box.wo.winhighlight) then
+          self.box_wins[box.id].opts.wo.winhighlight = Snacks.picker.highlight.winhl("SnacksPickerBox")
+        end
       end
     end
   end)

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -270,11 +270,6 @@ function M:init_layout(layout)
   }))
   self:attach()
 
-  -- apply box highlight groups
-  local boxwhl = Snacks.picker.highlight.winhl("SnacksPickerBox")
-  for _, win in pairs(self.layout.box_wins) do
-    win.opts.wo.winhighlight = boxwhl
-  end
   return layout
 end
 


### PR DESCRIPTION
## Description

For now，the layout's config such as:

```lua
{
    layout = {
        backdrop = false,
        relative = "cursor",
        width = 0.5,
        min_width = 80,
        height = 0.4,
        min_height = 3,
        box = "vertical",
        border = "rounded",
        title = "{title}",
        title_pos = "center",
        wo = {
            winhighlight = "FloatBorder:LspWinCodeActionBorder,FloatTitle:LspWinCodeActionTitle",
        },
        {
            win = "input",
            height = 1,
            border = "bottom",
            wo = {
                winhighlight = "FloatBorder:LspWinCodeActionBorder"
            }
        },
        { win = "list",    border = "none" },
        { win = "preview", title = "{preview}", height = 0.4, border = "top" },
    },
}
```

the `layout.wo.winhighlight ` does not work for box wins.

This PR make the config above work.

The stylua issue has been fixed.