### PR TITLE
fix(input): don't enter `insert` mode from `normal` confirm on `input`

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -233,6 +233,12 @@ function M.input(opts, on_confirm)
   vim.fn.prompt_setcallback(win.buf, function(text)
     confirm(text)
     win:close()
+    vim.schedule(function()
+      if mode ~= "i" then
+        vim.cmd("stopinsert")
+        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<Right>", true, true, true), "n", false)
+      end
+    end)
   end)
   vim.fn.prompt_setinterrupt(win.buf, function()
     confirm()


### PR DESCRIPTION
## Description
When pressing `<CR>` for the `confirm` action on `input` prompt buffer from `normal` mode, you get dropped in `insert` mode when you get back to the normal buffer. Probably similar behavor to the `snacks.picker`.

I pondered if the `stopinsert()` should go into the `confirm` function instead, but because I also implemented `nvim_feedkeys`, so that the cursor wouldn't move to the left due to the transition from `insert` to `normal` mode, I noticed that this would move the cursor to the right when confirming from `insert` mode and thought it would be undesirable. 

That's why in the end I opted for putting this in the prompt buffer callback instead.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #1466 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

