### PR TITLE
fix(image): markdown inline link query for shortened urls

### DIFF
--- a/queries/markdown_inline/images.scm
+++ b/queries/markdown_inline/images.scm
@@ -1,8 +1,8 @@
 
-(image 
+(image
   [
     (link_destination) @image.src
-    (image_description (shortcut_link (link_text) @image.src))
+    (image_description (shortcut_link ((link_text) @image.src)))
   ]
     (#gsub! @image.src "|.*" "") ; remove wikilink image options
     (#gsub! @image.src "^<" "") ; remove bracket link


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
This fixes the `image.src` capture for markdown shortcut links, which (imho) are links like `![[attachments/test.jpg]]`.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

