### PR TITLE
fix(snacks.dashboard): Docs had an undefined variable

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -161,7 +161,8 @@ In the example below, both sections are equivalent.
   formats = {
     icon = function(item)
       if item.file and item.icon == "file" or item.icon == "directory" then
-        return M.icon(item.file, item.icon)
+        local icon, hl = require('snacks').util.icon(item.file, item.icon)
+        return { icon, width = 2, hl = hl }
       end
       return { item.icon, width = 2, hl = "icon" }
     end,


### PR DESCRIPTION
## Description

Docks had a `M.icon` variable that users will just copy paste in their configs breaking the dashboard

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

