### PR TITLE
fix(image): improve default latex template and latex test page

### DIFF
--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -147,19 +147,26 @@ local defaults = {
         ${content}]],
     },
     latex = {
-      font_size = "Large", -- see https://www.sascha-frank.com/latex-font-size.html
+      font_size = "large", -- see https://www.sascha-frank.com/latex-font-size.html
       -- for latex documents, the doc packages are included automatically,
       -- but you can add more packages here. Useful for markdown documents.
       packages = { "amsmath", "amssymb", "amsfonts", "amscd", "mathtools" },
       tpl = [[
-        \documentclass[preview,border=0pt,varwidth,12pt]{standalone}
+        \documentclass[a3paper,12pt]{article}
         \usepackage{${packages}}
+        \usepackage{geometry}
+        \geometry{a3paper, margin=1cm}
         \begin{document}
+        \pagestyle{empty}
         ${header}
-        { \${font_size} \selectfont
+        { 
+          \${font_size} 
+          \selectfont
           \color[HTML]{${color}}
-        ${content}}
-        \end{document}]],
+          ${content}
+        }
+        \end{document}
+      ]],
     },
   },
 }

--- a/tests/image/test.tex
+++ b/tests/image/test.tex
@@ -81,17 +81,17 @@ Maxwell's equations:
 \nabla \times \textbf{E}=\frac{\rho}{\epsilon_0}
 \end{equation}
 
-\begin{equation}
+\begin{equation*}
 \nabla \cdot \textbf{H}=0
-\end{equation}
+\end{equation*}
 
-\begin{equation}
+\begin{equation*}
 \nabla \times \textbf{E}=-\frac 1c\frac{\partial \textbf{H}}{\partial t}
-\end{equation}
+\end{equation*}
 
-\begin{equation}
+\begin{equation*}
 \nabla \times \textbf{H}=\frac 1c\frac{\partial \textbf{E}}{\partial t}
-\end{equation}
+\end{equation*}
 
 Schroedinger equation:
 
@@ -126,10 +126,10 @@ Basel problem:
   \frac{\pi^2}{6}=\sum_{n=1}^\infty \frac{1}{n^2}
 \]
 
-Euler-Masceroni constant:
+Euler-Mascheroni constant:
 
 \[
-\gamma = \lim_{n\to\infty}(\sum_{n=1}^\infty \frac{1}{n}-\log n)\approx 0.5772156649\ldots
+\gamma = \lim_{n\to\infty}(\sum_{n=1}^\infty \frac{1}{n}-\log n)=\int_1^\infty\left(-\frac1x+\frac1{\lfloor x\rfloor}\right)\,\mathrm dx\approx 0.5772156649015328606065120\ldots
 \]
 
 Binomial expansion:
@@ -199,8 +199,46 @@ $$f(a)=\frac{1}{2\pi i}\int_{C} \frac{f(z)}{z-a} dz $$
 Stirling's factorial approximation:
 $$n! = \sqrt{2 \pi n} \left( \frac{n}{e} \right)^n \left( 1 + O \left( \frac{1}{n} \right) \right)$$
 
+Taylor's series:
+
+$$f(x)=\sum_{n=0}^\infty \frac{f^{(n)}(a)}{n!} (x-a)^n$$
+
+Graham's number, the biggest number ever used in a scientific paper:
+
+\[
+\left.
+ \begin{matrix}
+  G &=&3\underbrace{\uparrow \uparrow \cdots \cdots \cdots \cdots \cdots \uparrow}3 \\
+    & &3\underbrace{\uparrow \uparrow \cdots \cdots \cdots \cdots \uparrow}3 \\
+    & & \underbrace{\qquad \quad \vdots \qquad \quad} \\
+    & &3\underbrace{\uparrow \uparrow \cdots \cdots \uparrow}3 \\
+    & &3\uparrow \uparrow \uparrow \uparrow3
+ \end{matrix}
+\right \} \text{64 layers}
+\]
+
+Prime number approximation:
+
+$$ n \left( \log n + \log \log n - 1 + \frac{\log \log n - 2.1}{\log n} \right) \le p_n \le n \left( \log n + \log \log n - 1 + \frac{\log \log n - 2}{\log n} \right)$$
+
+Prime counting function approximation:
+
+\[
+\frac{x}{\log x} \left( 1 + \frac{1}{\log x} + \frac{2}{\log^2 x} \right) \le \pi(x) \le \frac{x}{\log x} \left( 1 + \frac{1}{\log x} + \frac{2}{\log^2 x} + \frac{7.59}{\log^3 x} \right)
+\]
+
+Riemann's zeta function (automatically scaled to fit the allowed width):
+
+\[
+\zeta(s) = \sum_{n=1}^\infty \frac{1}{n^s} = \frac{1}{\Gamma(s)} \int_0^\infty \frac{x ^ {s-1}}{e ^ x - 1} \, \mathrm{d}x = \prod_{p \text{ prime}} \frac{1}{1-p^{-s}} = \frac{1}{1-2^{-s}}\cdot\frac{1}{1-3^{-s}}\cdot\frac{1}{1-5^{-s}}\cdot\frac{1}{1-7^{-s}}\cdot\frac{1}{1-11^{-s}} \cdots \frac{1}{1-p^{-s}} \cdots
+\]
+
+The most famous unsolved mathematical problem (Riemann's hypothesis):
+
+\[
+  \zeta(s) = \sum_{n=1}^\infty \frac{1}{n^s} = 0\ \land \ \mathrm{Re}(s) > 0 \implies \mathrm{Re}(s)=\frac12
+\]
+
 \end{document}
-
-
 
 


### PR DESCRIPTION
Current latex template defined in lua/snacks/image/init.lua is based on a {standalone} document that has limited width and many other limitations (does not work with equations unless preview class is supplied). A class varwidth can be used to adjust the width of the paper (in order to fit a long equation), by providing the desired document width (varwidth=21cm, for example), but beyond certain width pdflatex compiler starts generating warnings that some elements are oversized. At the same time, \Large document font in a standalone Latex document, in combination with slightly longer equations often leads to cropped equations from the right side. that can be checked with the current implementation. Basically, current template is good for moderately sized equations but not big ones.

I suggest that we use a MUCH simpler latex template, standard document based on flexible {article}, with paper big enough to fit almost everything (A3). When magick trims the page, it's guaranteed that the whole content (equation) will be preserved. The template also works well when an equation is combined with desired font size (I have replaced \Large with \large which gives slightly smaller but (IMHO) better looking equation. 

I have also supplied a more complex test.tex  which proves that even if the equation is very long, it won't be cropped - it will be scaled down to fit the prescribed width (default is 80 cols and I think that this can also be slightly increased to 100, but I leave it up to you).  