### PR TITLE
fix(rename): `oil.nvim` snippet example

### DIFF
--- a/docs/rename.md
+++ b/docs/rename.md
@@ -22,8 +22,8 @@ vim.api.nvim_create_autocmd("User", {
 vim.api.nvim_create_autocmd("User", {
   pattern = "OilActionsPost",
   callback = function(event)
-      if event.data.actions.type == "move" then
-          Snacks.rename.on_rename_file(event.data.actions.src_url, event.data.actions.dest_url)
+      if event.data.actions[1].type == "move" then
+          Snacks.rename.on_rename_file(event.data.actions[1].src_url, event.data.actions[1].dest_url)
       end
   end,
 })


### PR DESCRIPTION
## Description

Quick fix In the `rename` plugin docs, the example code snippet for `oil.nvim` needs to take the first item from the  action list :)

