### PR TITLE
Fix padding mismatch in plugin config to align with preview

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -294,9 +294,9 @@ A simple example with a header, keys, recent files, and projects
 {
   sections = {
     { section = "header" },
-    { section = "keys", gap = 1 },
-    { icon = " ", title = "Recent Files", section = "recent_files", indent = 2, padding = { 2, 2 } },
-    { icon = " ", title = "Projects", section = "projects", indent = 2, padding = 2 },
+    { section = "keys", gap = 1, padding = 2 },
+    { icon = " ", title = "Recent Files", section = "recent_files", indent = 2, padding = 0 },
+    { icon = " ", title = "Projects", section = "projects", indent = 2, padding = 0 },
     { section = "startup" },
   },
 }


### PR DESCRIPTION
## Description

This PR updates the padding values in the plugin’s configuration file to align with the layout preview shown in the README. The previous configuration caused a mismatch in spacing, particularly in the keys, recent_files, and projects sections. Adjusting these values ensures proper alignment and consistency with the intended UI.

## Screenshots
<img width="806" alt="image" src="https://github.com/user-attachments/assets/4ced0073-73c6-4d97-9600-035c0b887eb3" />

