### PR TITLE
fix(picker): use path in directory preview ls

### DIFF
--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -12,7 +12,7 @@ function M.directory(ctx)
   local name = path and vim.fn.fnamemodify(path, ":t")
   ctx.preview:set_title(ctx.item.title or name)
   local ls = {} ---@type {file:string, type:"file"|"directory"}[]
-  for file, t in vim.fs.dir(ctx.item.file) do
+  for file, t in vim.fs.dir(path) do
     ls[#ls + 1] = { file = file, type = t }
   end
   ctx.preview:set_lines(vim.split(string.rep("\n", #ls), "\n"))


### PR DESCRIPTION
## Description

This patch lets the `directory` preview use the path determined by `Snacks.picker.util.path` to `ls` the files.

Using this in `picker.sources`:
```lua
dirs = {
  preview = 'directory',
  finder = function(opts, ctx)
    return require("snacks.picker.source.proc").proc({
      opts,
      {
        cmd = 'fdfind',
        args = { '--type', 'd', '--color', 'never', '-E', '.git' },
        ---@param item snacks.picker.finder.Item
        transform = function(item)
          item.file =  item.text
          item.cwd = opts.cwd
        end,
      },
    }, ctx)
  end
},
```