### PR TITLE
feat(bufdelete): added an option to cancel closing multiple buffers with bufdelete

### DIFF
--- a/lua/snacks/bufdelete.lua
+++ b/lua/snacks/bufdelete.lua
@@ -31,7 +31,10 @@ function M.delete(opts)
   if type(opts.filter) == "function" then
     for _, b in ipairs(vim.tbl_filter(opts.filter, vim.api.nvim_list_bufs())) do
       if vim.bo[b].buflisted then
-        M.delete(vim.tbl_extend("force", {}, opts, { buf = b, filter = false }))
+        local res = M.delete(vim.tbl_extend("force", {}, opts, { buf = b, filter = false }))
+        if res == -1 then
+          return
+        end
       end
     end
     return
@@ -46,11 +49,11 @@ function M.delete(opts)
   end
   buf = buf == 0 and vim.api.nvim_get_current_buf() or buf
 
-  vim.api.nvim_buf_call(buf, function()
+  return vim.api.nvim_buf_call(buf, function()
     if vim.bo.modified and not opts.force then
       local ok, choice = pcall(vim.fn.confirm, ("Save changes to %q?"):format(vim.fn.bufname()), "&Yes\n&No\n&Cancel")
       if not ok or choice == 0 or choice == 3 then -- 0 for <Esc>/<C-c> and 3 for Cancel
-        return
+        return -1
       end
       if choice == 1 then -- Yes
         vim.cmd.write()


### PR DESCRIPTION
## Description

When using bufdelete close all on multiple unsaved buffers, and choosing cancel when the prompt shows up, bufdelete continues to try to close the following buffers as well.
This behavior is a little strange, if I would want to save the buffer, I would have chosen yes, if I wanted to discard the changes, I would have chosen no. If I chose cancel/Ctrl-C the logical thing would be cancel the whole bulk operation and let the user perform any modifications they might deem necessary before proceeding.

This would allow a user to define an autocommand on PreExit to call bufdelete all and get a prompt for each unsaved buffer, deciding if he would like to save the changes or not, and also allowing to cancel the whole operation and stop nvim from exiting. This behavior is the normal behavior in numerous application including office applications preventing unintentional data loss.

This PR provides the described desired functionality

## Related Issue(s)

  - Fixes #1513 

