### PR TITLE
fix(scratch): branch fallback for detached head

### DIFF
--- a/lua/snacks/scratch.lua
+++ b/lua/snacks/scratch.lua
@@ -174,7 +174,7 @@ function M.open(opts)
     if opts.filekey.branch and uv.fs_stat(".git") then
       local ret = vim.fn.systemlist("git branch --show-current")[1]
       if vim.v.shell_error == 0 then
-        branch = ret
+        branch = ret or "" -- fallback for detached head (ret is nil then)
       end
     end
 


### PR DESCRIPTION
## Description

I work a lot with detached `HEAD` in Git repos and noticed that the scratch files for those were missing in `Snacks.scratch.select()`.

When working with a detached head, the `git branch --show-current` returns an empty string, so ret will be `nil` in this case. This breaks the scratch filename generation. The `table.concat` skips the `nil` value, so the generated filename is missing one `|` separator. This will later break in `M.list()`: `file_decode` and `match` will confuse `branch` and `ft`, and the entry is not added to the items list.

A simple fix for this is to fallback to an empty string for the branch name.

## Related Issue(s)

I didn't create an issue but fixed the problem right away. Hope this is fine.

## Screenshots

I can provide one if requested.