### PR TITLE
fix(scratch): hide buffer after formatting when close

### DIFF
--- a/lua/snacks/scratch.lua
+++ b/lua/snacks/scratch.lua
@@ -267,6 +267,7 @@ function M.open(opts)
       callback = function(ev)
         vim.api.nvim_buf_call(ev.buf, function()
           vim.cmd("silent! write")
+          vim.bo[ev.buf].buflisted = false
         end)
       end,
     })


### PR DESCRIPTION
## Description

When you format code in scratch, the scratch buffer will be opened in bufferline. The buffer will not disappear even after the scratch window is closed.

## Related Issue(s)

## Screenshots

![image](https://github.com/user-attachments/assets/463289c8-9a40-4a2f-ae13-65f2d142343c)
![image](https://github.com/user-attachments/assets/e9d058c6-dc9a-43d2-866b-26a33c272a96)
![image](https://github.com/user-attachments/assets/f8f46c66-a3f6-4d49-8442-7544ad2d0d02)


