### PR TITLE
fix(picker.preview): rectify hack for buffer-local window opts

### DIFF
--- a/lua/snacks/picker/core/preview.lua
+++ b/lua/snacks/picker/core/preview.lua
@@ -39,7 +39,7 @@ vim.api.nvim_create_autocmd("BufWinEnter", {
     local reset = { "winhighlight", "cursorline", "number", "relativenumber", "signcolumn" }
     local wo = {} ---@type table<string, any>
     for _, k in ipairs(reset) do
-      wo[k] = vim.api.nvim_get_option_value(k, { scope = "global" })
+      wo[k] = vim.api.nvim_get_option_value(k, { scope = "local" })
     end
     for _, win in ipairs(vim.fn.win_findbuf(ev.buf)) do
       if not Snacks.util.is_float(win) then -- only reset non-floating windows


### PR DESCRIPTION
## Description
The hack for buffer-local window options uses `scope = "global"` to get the options. But `Snacks.util.wo` sets local options regardless. I believe the hack should get the options with `scope = "local"`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #1524 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

