### PR TITLE
fix(lazygit): prevent error if no config file

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -88,7 +88,7 @@ local function env(opts)
       end, vim.split(vim.env.LG_CONFIG_FILE or "", ",", { plain = true }))
 
       -- add the default config file if it's not already there
-      if #config_files == 0 then
+      if #config_files == 0 and vim.fn.filereadable(config_dir .. "/config.yml") == 1 then
         config_files[1] = svim.fs.normalize(config_dir .. "/config.yml")
       end
 


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
It's erroring unless you create the actual file not even the directory.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

https://github.com/folke/snacks.nvim/issues/1548

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

