### PR TITLE
feat(dashboard): introducing support for full resolution dashboard images in terminals that support Kitty graphics protocol

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1062,7 +1062,7 @@ function M.sections.terminal(opts)
   end
 end
 
----@param opts {source:(string|fun(): string), height?:number, width?:number}|snacks.dashboard.Item
+---@param opts {source:(string|fun(): string), height?:number, width?:number, align?: "left"|"center"|"right}|snacks.dashboard.Item
 ---@return snacks.dashboard.Gen
 function M.sections.image(opts)
   -- if image source is a function, compute it. Take it as it is otherwise

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1062,23 +1062,11 @@ function M.sections.terminal(opts)
   end
 end
 
--- hash to prevent randomizing the same image url twice
-local randomized_urls = {}
-
----@param opts {src:string, height?:number, width?:number, randomize_src?:boolean}|snacks.dashboard.Item
+---@param opts {source:(string|fun(): string), height?:number, width?:number}|snacks.dashboard.Item
 ---@return snacks.dashboard.Gen
 function M.sections.image(opts)
   -- Ensure the URL starts with http, https, or ftp
-  local source = opts.src
-  if (source:match("^https?://") or source:match("^ftp://")) and opts.randomize_src then
-    if not randomized_urls[source] then
-      local query_param = "rand" .. math.random(100000, 999999) .. "=" .. math.random(100000, 999999)
-      local separator = source:find("?", 1, true) and "&" or "?"
-      local randomized_source = source .. separator .. query_param
-      randomized_urls[source] = randomized_source
-    end
-    source = randomized_urls[source]
-  end
+  local source = type(opts.source) == "function" and opts.source() or opts.source
   return function(self)
     local height = opts.height or 10
     local width = opts.width

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1065,7 +1065,7 @@ end
 -- hash to prevent randomizing the same image url twice
 local randomized_urls = {}
 
----@param opts {src:string, height?:number, width?:number, random_src_param?:boolean}|snacks.dashboard.Item
+---@param opts {src:string, height?:number, width?:number, randomize_src?:boolean}|snacks.dashboard.Item
 ---@return snacks.dashboard.Gen
 function M.sections.image(opts)
   -- Ensure the URL starts with http, https, or ftp

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1072,7 +1072,7 @@ function M.sections.image(opts)
   local source = opts.src
   if (source:match("^https?://") or source:match("^ftp://")) and opts.randomize_src then
     if not randomized_urls[source] then
-      local query_param = "rand" .. math.random(100000, 999999) .. "=" ..  math.random(100000, 999999)
+      local query_param = "rand" .. math.random(100000, 999999) .. "=" .. math.random(100000, 999999)
       local separator = source:find("?", 1, true) and "&" or "?"
       local randomized_source = source .. separator .. query_param
       randomized_urls[source] = randomized_source

--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -149,11 +149,13 @@ function M:progress()
   vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, {})
   vim.bo[self.buf].modifiable = false
   local timer = assert(uv.new_timer())
+  local extmark_id = nil
   timer:start(
     0,
     80,
     vim.schedule_wrap(function()
       if self:ready() or self.img:failed() or not vim.api.nvim_buf_is_valid(self.buf) then
+        vim.api.nvim_buf_del_extmark(self.buf, ns, extmark_id)
         timer:stop()
         if not timer:is_closing() then
           timer:close()
@@ -161,7 +163,7 @@ function M:progress()
         return
       end
       vim.api.nvim_buf_clear_namespace(self.buf, ns, 0, -1)
-      vim.api.nvim_buf_set_extmark(self.buf, ns, 0, 0, {
+      extmark_id = vim.api.nvim_buf_set_extmark(self.buf, ns, 0, 0, {
         virt_text = {
           { Snacks.util.spinner(), "SnacksImageSpinner" },
           { " " },

--- a/lua/snacks/image/util.lua
+++ b/lua/snacks/image/util.lua
@@ -59,31 +59,23 @@ function M.fit(file, cells, opts)
     img_pixels = M.dim(file)
   end
   local img_cells = M.pixels_to_cells(img_pixels)
-
-  local ret = vim.deepcopy(cells)
-  -- if not opts.full then
-  if img_cells.width <= cells.width and img_cells.height <= cells.height then
+  -- if the image is smaller than available space and scale-to-fit is turned off, return image size without change
+  if img_cells.width <= cells.width and img_cells.height <= cells.height and not opts.full then
     return img_cells
   end
-  ret.width = math.min(cells.width, img_cells.width)
-  ret.height = math.min(cells.height, img_cells.height)
-  -- end
-
-  local scale = ret.width / ret.height
-  local img_scale = img_cells.width / img_cells.height
-  local fit_height = math.floor(ret.width / img_scale + 0.5)
-  local fit_width = math.floor(ret.height * img_scale + 0.5)
-
-  if ret.height == fit_height or ret.width == fit_width then
-    -- Image fits exactly
-  elseif img_scale > scale then
-    -- Image is wider relative to height - fit to width
-    ret.height = fit_height
-  else
-    -- Image is taller relative to width - fit to height
-    ret.width = fit_width
-  end
-  return M.norm(ret)
+  -- horizontal scaling facotr
+  local scale_row = cells.width / img_cells.width
+  -- vertical scaling factor
+  local scale_height = cells.height / img_cells.height
+  -- choose smaller scale as the final one
+  local scale = math.min(scale_row, scale_height)
+  -- calculate scaled dimensions so that the image fits the available space
+  local result = M.norm({
+    width = img_cells.width * scale,
+    height = img_cells.height * scale,
+  })
+  return result
 end
 
 return M
+


### PR DESCRIPTION
(as of April 7, all suggestions and changes have been implemented and the following text has been updated accordingly)

Current dashboard implementation does not allow "real" images on snacks dashboard. All that you can get is chafa-like images that are just plain ugly (unless you are happy with character blocks colored with some almost random color). The real image is almost unrecognizable. In Kitty and several other terminals it is possible to render image natively. And all support for it is already there, built into snacks. I have just connected some simple dots. 

<img width="1284" alt="1" src="https://github.com/user-attachments/assets/d9d6f831-c8a6-43da-922f-d527fe7a3f2b" />

![s1](https://github.com/user-attachments/assets/b65816ce-da70-4919-a3df-94016fc39969)

Isn't it nice? :)

Here is my dashboard configuration:

```
return {
  {
    "folke/snacks.nvim",
    enabled = true,
    priority = 1000,
    lazy = false,
    ---@type snacks.Config
    opts = {
      ...
      dashboard = {
        enabled = true,
        sections = {
          {
            section = "header",
            padding = 1
          },
          {
            align = "center",
            text = {
              { nvimInfo, hl = "SnacksDashboardHeader" },
            },
          },
          { icon = " ", title = "Keymaps", section = "keys", indent = 2, padding = 0 },
          {
            action = ":Neorg index",
            key = "o",
            desc = "Neorg Index Page",
            icon = " ",
            indent = 2,
          },
          {
            action = ":Neorg journal today",
            key = "j",
            desc = "Neorg Journal Today",
            icon = " ",
            indent = 2,
            padding = 1,
          },
          { icon = " ", title = "Recent Files", section = "recent_files", indent = 2, padding = 1 },
          { icon = " ", title = "Projects", section = "projects", indent = 2, padding = 1 },
          {
            align = "center",
            pane = 2,
            text = {
              { "Enjoy the day", hl = "SnacksDashboardHeader" },
            },
          },
          {
            section = "image",
            pane = 2,
            -- width = 25,
            height = 25,
            align = "center",
            -- source can be a function that returns location (path or url) or a string representing the location 
            source = function() return "https://picsum.photos/600/600/?rnd=" .. math.random(1, 1000000) end,
            -- source = "https://movies.luka.in.rs/api/user/movie/picture/pp__5020__d5eBZq.jpg?1fdfd2345dd67",
            -- source = "~/Downloads/4.jpeg",
            padding = 1,
          },
          {
            section = "terminal",
            cmd = "fortune -s",
            height = 2,
            pane = 2,
            padding = 1,
          },
          {
            section = "startup",
            -- pane = 2,
          },
        },
      },
      indent = {
        enabled = true
      },
      scroll = {
        enabled = true
      },
    },
  }
}
```

Notice that there is a new section ("image"). Image source is a web URL or a path to a local image, or a function that returns URL or path. In this particular case image is obtained from "picsum" online service. Snacks cashes images so by calling the same URL you'll get the same image from the cache. Because of that source key is a function that appends some random parameter to the URL. You always get one new image per session because URLs do not match strictly! 

To function properly, a bug in placement.lua file has to be fixed as well (which I did). The code places extmark while image is being converted but it does not do proper cleanup when the conversion is over. That leaves an ugly image processing message on the screen above the image.

I have also changed a piece of image utils by simplifying logic that fits an image into available space.

Key image options:

- **width**: a number, maximum image width (cells)
- **height**: a number maximum image height (cells)
- **align**: one of the following strings: "left", "center" or "right"; if omitted, defaults to "left"

Note that if you supply "title" as image option, it will be rendered, but it does not obey alignment setting. If you need title above the image, use separate section, as I did in my configuration file.

I believe this is a logical addition to snacks.dashboard - why stay limited to chafa in the era of kitty and other terminals that handle native images perfectly?
