### PR TITLE
feat(picker): add toggle_regex for grep

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -352,6 +352,19 @@ M.grep = {
   show_empty = true,
   live = true, -- live grep by default
   supports_live = true,
+  actions = {
+    toggle_regex = function(picker)
+      picker.opts.regex = not picker.opts.regex
+      picker:find()
+    end,
+  },
+  win = {
+    input = {
+      keys = {
+        ["<a-r>"] = { "toggle_regex", mode = { "n", "i" }, desc = "Toggle Regex" },
+      },
+    },
+  },
 }
 
 ---@type snacks.picker.grep.Config|{}


### PR DESCRIPTION
## Description

This PR adds a new keymap `<a-r>` for toggling the regex in grep picker.

It allows user to get faster when searching some special strings like `$props()`, or just put a part of line `test to jump faster.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

https://github.com/user-attachments/assets/2442b21c-898f-4682-a966-5a82abdd23e8




