### PR TITLE
feat(terminal): add position field to terminal.Opts

### DIFF
--- a/lua/snacks/terminal.lua
+++ b/lua/snacks/terminal.lua
@@ -22,6 +22,7 @@ local defaults = {
 
 ---@class snacks.terminal.Opts: snacks.terminal.Config
 ---@field cwd? string
+---@field position? "float"|"bottom"|"top"|"left"|"right"
 ---@field env? table<string, string>
 ---@field start_insert? boolean start insert mode when starting the terminal
 ---@field auto_insert? boolean start insert mode when entering the terminal buffer
@@ -83,9 +84,13 @@ end
 ---@param opts? snacks.terminal.Opts
 function M.open(cmd, opts)
   local id = vim.v.count1
+  local position = cmd and "float" or "bottom"
+  if opts and opts.position then
+    position = opts.position
+  end
   opts = Snacks.config.get("terminal", defaults --[[@as snacks.terminal.Opts]], opts)
   opts.win = Snacks.win.resolve("terminal", {
-    position = cmd and "float" or "bottom",
+    position = position,
   }, opts.win, { show = false })
   opts = vim.deepcopy(opts)
   opts.win.wo.winbar = opts.win.wo.winbar


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
I added a position field to `snacks.terminal.Opts`.
Previously, the terminal position was determined based on the `cmd`. 
If the command was provided, the position was set to "float", and it was otherwise "bottom".
The the position field is present, it overrides the position set by `cmd`, and if not provided, the old behavior is preserved.

## Related Issue(s)
- Fixes #1606 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->