### PR TITLE
fix: nil check before setting extmark

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -312,14 +312,17 @@ function M.render_scope(scope, state)
   local col = indent - state.leftcol
 
   if config.scope.underline and scope.from == from then
-    vim.api.nvim_buf_set_extmark(scope.buf, ns, scope.from - 1, math.max(col, 0), {
-      end_col = #vim.api.nvim_buf_get_lines(scope.buf, scope.from - 1, scope.from, false)[1],
-      hl_group = get_underline_hl(hl),
-      hl_mode = "combine",
-      priority = config.scope.priority + 1,
-      strict = false,
-      ephemeral = true,
-    })
+    local scope_first_line = vim.api.nvim_buf_get_lines(scope.buf, scope.from - 1, scope.from, false)[1]
+    if scope_first_line ~= nil then
+      vim.api.nvim_buf_set_extmark(scope.buf, ns, scope.from - 1, math.max(col, 0), {
+        end_col = #scope_first_line,
+        hl_group = get_underline_hl(hl),
+        hl_mode = "combine",
+        priority = config.scope.priority + 1,
+        strict = false,
+        ephemeral = true,
+      })
+    end
   end
 
   if col < 0 then -- scope is hidden


### PR DESCRIPTION
## Description

Resolves the following error, which occurs when removing a visual line selection in a TypeScript file when `indent.scope.underline` is `true`:

```
  Error  Error in decoration provider snacks_indent.win:
Error executing lua: ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:317: attempt to get length of local 'scope_from' (a nil value)
stack traceback:
  ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:317: in function 'render_scope'
  ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:285: in function 'on_win'
  ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:496: in function <....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:494>
  [builtin#36]: at 0x7f91509530e0
  ...ghtly/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:307: in function 'handler'
  ...rapped-nightly/share/nvim/runtime/lua/vim/lsp/client.lua:679: in function ''
  vim/_editor.lua: in function <vim/_editor.lua:0>
Error in decoration provider snacks_indent.win:
Error executing lua: ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:317: attempt to get length of local 'scope_from' (a nil value)
stack traceback:
  ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:317: in function 'render_scope'
  ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:285: in function 'on_win'
  ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:496: in function <....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:494>
  [C]: in function 'nvim_command'
  ....local/share/nvim/lazy/nui.nvim/lua/nui/popup/border.lua:624: in function '_relayout'
  ...m/.local/share/nvim/lazy/nui.nvim/lua/nui/popup/init.lua:390: in function 'update_layout'
  ....local/share/nvim/lazy/noice.nvim/lua/noice/view/nui.lua:246: in function <....local/share/nvim/lazy/noice.nvim/lua/noice/view/nui.lua:245>
  [C]: in function 'pcall'
  ....local/share/nvim/lazy/noice.nvim/lua/noice/view/nui.lua:143: in function 'reset'
  ...local/share/nv
```

## Steps to reproduce

Edit a TypeScript file with the following contents:

```typescript
//

const test = {
};
````

Remove the file contents with `ggVGd` to trigger the error.