### PR TITLE
fix(dashboard): set `border = "none"` on `terminal` sections

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -1042,6 +1042,7 @@ function M.sections.terminal(opts)
           style = "minimal",
           width = width,
           win = self.win,
+          border = "none",
         })
         local hl = opts.hl and hl_groups[opts.hl] or opts.hl or "SnacksDashboardTerminal"
         Snacks.util.wo(win, { winhighlight = "TermCursorNC:" .. hl .. ",NormalFloat:" .. hl })


### PR DESCRIPTION
## Description

Since 0.11, a new `vim.o.winborder` global option sets the borders for all floating windows. Override this for terminal sections.