### PR TITLE
feat(explorer): add `open_all`

### DIFF
--- a/lua/snacks/explorer/actions.lua
+++ b/lua/snacks/explorer/actions.lua
@@ -126,6 +126,11 @@ function M.actions.explorer_close_all(picker)
   M.update(picker, { refresh = true })
 end
 
+function M.actions.explorer_open_all(picker)
+  Tree:open_all(picker:cwd())
+  M.update(picker, { refresh = true })
+end
+
 function M.actions.explorer_git_next(picker, item)
   local node = Git.next(picker:cwd(), item and item.file)
   if node then

--- a/lua/snacks/explorer/tree.lua
+++ b/lua/snacks/explorer/tree.lua
@@ -302,6 +302,13 @@ function Tree:close_all(cwd)
 end
 
 ---@param cwd string
+function Tree:open_all(cwd)
+  self:walk(self:find(cwd), function(node)
+    node.open = true
+  end, { all = true })
+end
+
+---@param cwd string
 ---@param filter fun(node: snacks.picker.explorer.Node):boolean?
 ---@param opts? {up?: boolean, path?: string}
 function Tree:next(cwd, filter, opts)


### PR DESCRIPTION
Add a way to open all directories in the explorer at once, as a counterpart to the existing `close_all`.

This makes the explorer way more useful to me, making it possible to get an overview of the files in a project without having to press too many keys.

This implementation doesn't work recursively, which I guess can be viewed as either a bug or a feature.

## Description

See commit message. Not sure if this is something that other people want, just a suggestion. 

Thank you Folke and all other contributors to this wonderful project :) 

