### PR TITLE
feat(explorer): Support Expander Icons in the Explorer Tree

### DIFF
--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -505,6 +505,11 @@ below.
           dir_open = "󰝰 ",
           file = "󰈔 "
         },
+        expanders = {
+          enabled = false,
+          dir = " ",
+          dir_open = " ",
+        },
         keymaps = {
           nowait = "󰓅 "
         },

--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -505,11 +505,6 @@ below.
           dir_open = "󰝰 ",
           file = "󰈔 "
         },
-        expanders = {
-          enabled = false,
-          dir = " ",
-          dir_open = " ",
-        },
         keymaps = {
           nowait = "󰓅 "
         },
@@ -517,6 +512,11 @@ below.
           vertical = "│ ",
           middle   = "├╴",
           last     = "└╴",
+          expanders = {
+            enabled = false,
+            closed = " ",
+            open = " ",
+          },
         },
         undo = {
           saved   = " ",

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -329,6 +329,11 @@ Snacks.picker.pick({source = "files", ...})
       dir_open = "󰝰 ",
       file = "󰈔 "
     },
+    expanders = {
+      enabled = false,
+      dir = " ",
+      dir_open = " ",
+    },
     keymaps = {
       nowait = "󰓅 "
     },
@@ -772,6 +777,7 @@ Implementation for `vim.ui.select`
 ---@type snacks.picker.ui_select
 Snacks.picker.select(...)
 ```
+
 ## 🔍 Sources
 
 ### `autocmds`
@@ -2357,7 +2363,6 @@ M.sidebar
 }
 ```
 
-
 ## 📦 `snacks.picker.actions`
 
 ```lua
@@ -2730,8 +2735,6 @@ Snacks.picker.actions.toggle_preview(picker)
 ```lua
 Snacks.picker.actions.yank(picker, item, action)
 ```
-
-
 
 ## 📦 `snacks.picker.core.picker`
 

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -329,11 +329,6 @@ Snacks.picker.pick({source = "files", ...})
       dir_open = "󰝰 ",
       file = "󰈔 "
     },
-    expanders = {
-      enabled = false,
-      dir = " ",
-      dir_open = " ",
-    },
     keymaps = {
       nowait = "󰓅 "
     },
@@ -341,6 +336,11 @@ Snacks.picker.pick({source = "files", ...})
       vertical = "│ ",
       middle   = "├╴",
       last     = "└╴",
+      expanders = {
+        enabled = false,
+        closed = " ",
+        open = " ",
+      },
     },
     undo = {
       saved   = " ",

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -326,6 +326,11 @@ local defaults = {
       dir_open = "󰝰 ",
       file = "󰈔 "
     },
+    expanders = {
+      enabled = false,
+      dir = " ",
+      dir_open = " ",
+    },
     keymaps = {
       nowait = "󰓅 "
     },

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -326,11 +326,6 @@ local defaults = {
       dir_open = "󰝰 ",
       file = "󰈔 "
     },
-    expanders = {
-      enabled = false,
-      dir = " ",
-      dir_open = " ",
-    },
     keymaps = {
       nowait = "󰓅 "
     },
@@ -338,6 +333,11 @@ local defaults = {
       vertical = "│ ",
       middle   = "├╴",
       last     = "└╴",
+      expanders = {
+        enabled = false,
+        closed = " ",
+        open = " ",
+      },
     },
     undo = {
       saved   = " ",

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -256,6 +256,9 @@ function M.tree(item, picker)
     node = node.parent
   end
   ret[#ret + 1] = { table.concat(indent), "SnacksPickerTree" }
+  if item.dir and picker.opts.icons.expanders.enabled ~= false then
+    ret[#ret + 1] = { item.open and picker.opts.icons.expanders.dir_open or picker.opts.icons.expanders.dir }
+  end
   return ret
 end
 

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -249,6 +249,8 @@ function M.tree(item, picker)
     local is_last, icon = node.last, ""
     if node ~= item then
       icon = is_last and "  " or icons.vertical
+    elseif item.dir and icons.expanders.enabled ~= false then
+      icon = item.open and icons.expanders.open or icons.expanders.closed
     else
       icon = is_last and icons.last or icons.middle
     end
@@ -256,9 +258,6 @@ function M.tree(item, picker)
     node = node.parent
   end
   ret[#ret + 1] = { table.concat(indent), "SnacksPickerTree" }
-  if item.dir and picker.opts.icons.expanders.enabled ~= false then
-    ret[#ret + 1] = { item.open and picker.opts.icons.expanders.dir_open or picker.opts.icons.expanders.dir }
-  end
   return ret
 end
 


### PR DESCRIPTION
## Description
This PR supports expander icons in the explorer tree. This is native to [Neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim) and some people (including myself) are probably interested in using the snacks file explorer while having this nice directory representation. 
> [!NOTE]
> I'm not entirely sure if this should be enabled by default, so I left it disabled to be safe. This makes the feature backward compatible and only supported if users want to opt in. I think it could be a nice default though. 

## Related Issue(s)
N/A

## Screenshots
### With icons enabled
![image](https://github.com/user-attachments/assets/80d1c558-0f68-4e89-b6f6-496274582c38)

### With icons disabled
![image](https://github.com/user-attachments/assets/9152e732-a73d-4b50-b609-545e74994861)