### PR TITLE
fix: fixing explorer crashes when deleting

### DIFF
--- a/lua/snacks/explorer/watch.lua
+++ b/lua/snacks/explorer/watch.lua
@@ -16,6 +16,10 @@ function M.start(path, cb)
   end
   local handle = assert(vim.uv.new_fs_event())
   local ok, err = handle:start(path, {}, function(_, file, events)
+    if not file then
+      return -- Prevent crash on directory-level event
+    end
+
     file = path .. "/" .. file
     if cb then
       cb(file, events)


### PR DESCRIPTION
Fixes a crash that occurred when deleting folders via the explorer. The issue was caused by a nil file value being passed to the file system watcher's callback, which led to a failed string concatenation. This PR adds a nil check in watch.lua to safely handle such cases.

Additionally, the explorer_del action now filters out invalid paths and prevents accidental deletion of the current working directory, improving overall stability and user safety.

Related Issue(s)
Fixes https://github.com/folke/snacks.nvim/issues/1679

Root cause: file can be nil in uv.new_fs_event callback when a directory is removed.

![Screenshot 2025-04-04 104938](https://github.com/user-attachments/assets/891b1f3f-670c-4239-9d71-07430721749c)




