### PR TITLE
feat(statuscolumn): enable showing both relative and standard line numbers

### DIFF
--- a/lua/snacks/statuscolumn.lua
+++ b/lua/snacks/statuscolumn.lua
@@ -20,6 +20,7 @@ M.meta = {
 ---@field left snacks.statuscolumn.Components
 ---@field right snacks.statuscolumn.Components
 ---@field enabled? boolean
+---@field show_both_line_numbers? boolean
 local defaults = {
   left = { "mark", "sign" }, -- priority of signs on the left (high to low)
   right = { "fold", "git" }, -- priority of signs on the right (high to low)
@@ -32,6 +33,7 @@ local defaults = {
     patterns = { "GitSign", "MiniDiffSign" },
   },
   refresh = 50, -- refresh at most every 50ms
+  show_both_line_numbers = false,
 }
 
 local config = Snacks.config.get("statuscolumn", defaults)
@@ -191,7 +193,11 @@ function M._get()
     if rnu and nu and vim.v.relnum == 0 then
       num = vim.v.lnum
     elseif rnu then
-      num = vim.v.relnum
+      if config.show_both_line_numbers then
+        num = vim.v.lnum .. " " .. vim.v.relnum
+      else
+        num = vim.v.relnum
+      end
     else
       num = vim.v.lnum
     end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Adding the capability to enable both actual and relative line numbers at the same time.
- A new configuration option is available to configure this setting: `show_both_line_numbers`.
- This setting defaults to `false`
- This was a feature request in discussions and I also found this would be useful :). I implemented it with their configuration format in mind `nu <space> relnu`, but am open to any formatting (ie. `nu | relnu`)
- https://github.com/folke/snacks.nvim/issues/1681

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
https://github.com/user-attachments/assets/9943f1cd-87eb-4220-a780-f328aaca8024