### PR TITLE
feat(picker): use `ivy_split` preset for sources.lines

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -467,7 +467,7 @@ M.lines = {
   format = "lines",
   layout = {
     preview = "main",
-    preset = "ivy",
+    preset = "ivy_split",
   },
   jump = { match = true },
   -- allow any window to be used as the main window


### PR DESCRIPTION
## Description

As far as I can tell, it should be `'ivy_split'`. The `preview = "main"` property can also be deleted.