### PR TITLE
Fix the erroneous Folded highlight for fold sign.

### DIFF
--- a/lua/snacks/statuscolumn.lua
+++ b/lua/snacks/statuscolumn.lua
@@ -143,7 +143,7 @@ function M.line_signs(win, buf, lnum)
   -- Get fold signs
   vim.api.nvim_win_call(win, function()
     if vim.fn.foldclosed(lnum) >= 0 then
-      signs[#signs + 1] = { text = vim.opt.fillchars:get().foldclose or "", texthl = "Folded", type = "fold" }
+      signs[#signs + 1] = { text = vim.opt.fillchars:get().foldclose or "", type = "fold" }
     elseif config.folds.open and vim.fn.foldlevel(lnum) > vim.fn.foldlevel(lnum - 1) then
       signs[#signs + 1] = { text = vim.opt.fillchars:get().foldopen or "", type = "fold" }
     end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Small modification for the fold sign, which has no reason to have "Folded" texthl.

## Related Issue(s)
- Fixes #1704 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
Before:
![截图 2025-04-08 00-41-13](https://github.com/user-attachments/assets/0d63d9e5-116a-4015-809b-0d6f5c7f9309)

After:
![截图 2025-04-08 00-59-47](https://github.com/user-attachments/assets/ad97aeba-d776-4b55-aea3-0bc9fc6bdb24)

