### PR TITLE
fix(image): images not being inlined inside tmux

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -181,6 +181,25 @@ local commands = {
       }
     end,
   },
+  drawio = {
+    cmd = {
+      {
+        cmd = "drawio",
+        args = {
+          "--export",
+          "--transparent",
+          "--format",
+          "png",
+          "--output",
+          "{file}",
+          "{src}",
+        },
+      },
+    },
+    file = function(convert, ctx)
+      return convert:tmpfile("png")
+    end,
+  },
 }
 
 local have = {} ---@type table<string, boolean>
@@ -245,7 +264,24 @@ function Convert.new(opts)
   if M.is_uri(self.opts.src) then
     base = self.opts.src:gsub("%?.*", ""):match("^%w%w+://(.*)$") or base
   end
-  self.prefix = vim.fn.sha256(self.opts.src):sub(1, 8) .. "-" .. base:gsub("[^%w%.]+", "-")
+
+  -- TODO: refactor to be able to configure by file type the
+  -- formats that will be cached based on file contents
+
+  local hash_input = opts.src
+  local ext = vim.fn.fnamemodify(self.src, ":e"):lower()
+  if not M.is_uri(opts.src) and ext == "drawio" then
+    local fd = io.open(opts.src, "rb")
+    if fd then
+      hash_input = fd:read("*a")
+      fd:close()
+    end
+  end
+
+  -- compute sha256 of the data
+  local h = vim.fn.sha256(hash_input):sub(1, 8)
+  self.prefix = h .. "-" .. base:gsub("[^%w%.]+", "-")
+
   self.meta = { src = opts.src }
   self.steps = {}
   self.tpl_data = {

--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -31,6 +31,8 @@ local environments = {
   {
     name = "tmux",
     env = { TERM = "tmux", TMUX = true },
+    supported = true,
+    placeholders = true,
     setup = function()
       pcall(vim.fn.system, { "tmux", "set", "-p", "allow-passthrough", "all" })
     end,


### PR DESCRIPTION
## Description
  
Currently images are not properly aligned in tmux, and floating mode is the only mode available. This minor change enables that.
 
 ```
 ~
❮ kitty --version
kitty 0.40.0 created by Kovid Goyal

~
❮ tmux -V
tmux 3.5a

~
❮ nvim --version
NVIM v0.11.0
Build type: Release
LuaJIT 2.1.1741730670
Run "nvim -V1 -v" for more info
 ```

## Screenshots


https://github.com/user-attachments/assets/f43d2fcd-804a-4664-9fc1-704bc6c83d77


https://github.com/user-attachments/assets/a589915b-19b3-4c11-8af2-ffadd8294003


