### PR TITLE
fix(image): prefer wget over curl

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -50,12 +50,12 @@ local commands = {
   url = {
     cmd = {
       {
-        cmd = "curl",
-        args = { "-L", "-o", "{file}", "{src}" },
-      },
-      {
         cmd = "wget",
         args = { "-O", "{file}", "{src}" },
+      },
+      {
+        cmd = "curl",
+        args = { "-L", "-o", "{file}", "{src}" },
       },
     },
     file = function(convert, ctx)


### PR DESCRIPTION
## Description

wget seems to work more out of the box, as with curl I get errors like:
```
curl: (3) URL rejected: Malformed input to a URL function
```

## Screenshots

before:


after:

