### PR TITLE
disable mini.icons when not loaded

### DIFF
--- a/lua/snacks/util/init.lua
+++ b/lua/snacks/util/init.lua
@@ -127,7 +127,7 @@ function M.icon(name, cat, opts)
   opts.fallback = opts.fallback or {}
   local try = {
     function()
-      return require("mini.icons").get(cat or "file", name)
+      return MiniIcons.get(cat or "file", name)
     end,
     function()
       if cat == "directory" then


### PR DESCRIPTION
## Description

use `MiniIcons` instead of `require("mini.icons")`, when not load `mini.icons`, there's no `MiniIcons` global variable

then, if not `require("mini.icons").setup()`, prefer to use `nvim-wbe-devicons`

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

https://github.com/folke/snacks.nvim/issues/558

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

