### PR TITLE
feat(picker): adds `center` field to `snacks.picker.jump.Config`

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -126,7 +126,11 @@ function M.jump(picker, _, action)
   end
   if pos and pos[1] > 0 then
     vim.api.nvim_win_set_cursor(win, { pos[1], pos[2] })
-    vim.cmd("norm! zzzv")
+    if picker.opts.jump.center then
+      vim.cmd("norm! zzzv")
+    else
+      vim.cmd("norm! zv")
+    end
   elseif item.search then
     vim.cmd(item.search)
     vim.cmd("noh")

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -185,6 +185,7 @@ local defaults = {
     reuse_win = false, -- reuse an existing window if the buffer is already open
     close = true, -- close the picker when jumping/editing to a location (defaults to true)
     match = false, -- jump to the first match position. (useful for `lines`)
+    center = true, -- center cursorline after jump
   },
   toggles = {
     follow = "f",


### PR DESCRIPTION
## Description

This adds the field, `center`, to `snacks.picker.jump.Config`.

Right now the default, hard-coded behavior is to `zz` after moving the cursor: https://github.com/folke/snacks.nvim/blob/bc0630e43be5699bb94dadc302c0d21615421d93/lua/snacks/picker/actions.lua#L129

So that the user can configure whether the window gets centered on the line with the item that was jumped to, I added the aforementioned new field, `center`. My personal reason for adding this is I prefer the window not to scroll when the target item being jumped to is within the visible/edit window to help keep my bearings within the code (e.g., I do a `gd` on a symbol for a call to `lsp_definitions`, and the definition is already within view — and `auto_confirm` is set to true).
