### PR TITLE
Allow specifying a page number for pdfs inside of markdown

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -120,11 +120,11 @@ local commands = {
     cmd = {
       {
         cmd = "magick",
-        args = { "identify", "-format", "%m %[fx:w]x%[fx:h] %xx%y", "{src}[0]" },
+        args = { "identify", "-format", "%m %[fx:w]x%[fx:h] %xx%y", "{src}[{page}]" },
       },
       {
         cmd = "identify",
-        args = { "-format", "%m %[fx:w]x%[fx:h] %xx%y", "{src}[0]" },
+        args = { "-format", "%m %[fx:w]x%[fx:h] %xx%y", "{src}[{page}]" },
       },
     },
     on_done = function(step)
@@ -152,7 +152,7 @@ local commands = {
     ft = "png",
     cmd = function(step)
       local formats = vim.deepcopy(Snacks.image.config.convert.magick or {})
-      local args = formats.default or { "{src}[0]" }
+      local args = formats.default or { "{src}[{page}]" }
       local info = step.meta.info
       local format = info and info.format or vim.fn.fnamemodify(step.meta.src, ":e")
 
@@ -222,6 +222,7 @@ end
 ---@class snacks.image.Convert
 ---@field opts snacks.image.convert.Opts
 ---@field src string
+---@field page number
 ---@field file string
 ---@field prefix string
 ---@field meta snacks.image.meta
@@ -237,6 +238,7 @@ Convert.__index = Convert
 function Convert.new(opts)
   vim.fn.mkdir(Snacks.image.config.cache, "p")
   local self = setmetatable({}, Convert)
+  opts.src, self.page = M.get_page(opts.src)
   opts.src = M.norm(opts.src)
   self.opts = opts
   self.src = opts.src
@@ -245,7 +247,7 @@ function Convert.new(opts)
   if M.is_uri(self.opts.src) then
     base = self.opts.src:gsub("%?.*", ""):match("^%w%w+://(.*)$") or base
   end
-  self.prefix = vim.fn.sha256(self.opts.src):sub(1, 8) .. "-" .. base:gsub("[^%w%.]+", "-")
+  self.prefix = vim.fn.sha256(self.opts.src .. self.page):sub(1, 8) .. "-" .. base:gsub("[^%w%.]+", "-")
   self.meta = { src = opts.src }
   self.steps = {}
   self.tpl_data = {
@@ -407,6 +409,7 @@ function Convert:step()
     name = vim.fn.fnamemodify(step.file, ":t:r"),
     dirname = vim.fs.dirname(step.meta.src),
     src = step.meta.src,
+    page = self.page,
   }, self.tpl_data)
 
   for a, arg in ipairs(args) do
@@ -465,6 +468,14 @@ function M.norm(src)
     src = svim.fs.normalize(vim.fn.fnamemodify(src, ":p"))
   end
   return src
+end
+
+---@param src string
+---@return string, number
+function M.get_page(src)
+  local parts = vim.split(src, "#page=", { plain = true })
+  local page_number = tonumber(parts[2]) or 1
+  return parts[1], page_number - 1
 end
 
 ---@param opts snacks.image.convert.Opts

--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -127,9 +127,9 @@ local defaults = {
     ---@type table<string,snacks.image.args>
     magick = {
       default = { "{src}[0]", "-scale", "1920x1080>" }, -- default for raster images
-      vector = { "-density", 192, "{src}[0]" }, -- used by vector images like svg
-      math = { "-density", 192, "{src}[0]", "-trim" },
-      pdf = { "-density", 192, "{src}[0]", "-background", "white", "-alpha", "remove", "-trim" },
+      vector = { "-density", 192, "{src}[{page}]" }, -- used by vector images like svg
+      math = { "-density", 192, "{src}[{page}]", "-trim" },
+      pdf = { "-density", 192, "{src}[{page}]", "-background", "white", "-alpha", "remove", "-trim" },
     },
   },
   math = {


### PR DESCRIPTION
## Description
Allow specifying a page number for pdfs inside of markdown.

This is done by adding "#page=<page-number>" to the file name. This is same way it is done in obsidian (as discussed in https://forum.obsidian.md/t/link-to-the-exact-page-of-and-external-pdf-file/2111)

I'm pretty new to lua, and this codebase, so this might not be the best code, but I hope it at least helps :D
## Related Issue(s)

  - Fixes #1805


