### PR TITLE
fix(picker.git_diff): use absolute path when adding buffer to avoid duplicates

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -95,8 +95,7 @@ function M.jump(picker, _, action)
       local buf = item.buf ---@type number
       if not buf then
         local path = assert(Snacks.picker.util.path(item), "Either item.buf or item.file is required")
-        local absolute_path = vim.fn.fnamemodify(path, ":p")
-        buf = vim.fn.bufadd(absolute_path)
+        buf = vim.fn.bufadd(path)
       end
       vim.bo[buf].buflisted = true
 


### PR DESCRIPTION
## Description

Uses absolute path for setting the cursor
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

Fixes #1818 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

