### PR TITLE
feat(dashboard): add a harpoon section in dashboard

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -885,7 +885,6 @@ function M.sections.harpoon(opts)
 
     for _, item in ipairs(items) do
       ret[#ret + 1] = {
-        title = vim.fn.fnamemodify(item.value, ":t"),
         file = item.value,
         icon = "file",
         action = function()

--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -869,6 +869,40 @@ function M.sections.recent_files(opts)
   end
 end
 
+function M.sections.harpoon(opts)
+  return function()
+    opts = opts or {}
+    local limit = opts.limit or 5
+
+    local ret = {} ---@type snacks.dashboard.Section
+    local ok, harpoon = pcall(require, "harpoon")
+
+    if not ok then
+      return ret
+    end
+    local harpoon_item = harpoon:list()
+    local items = harpoon_item.items
+
+    for _, item in ipairs(items) do
+      ret[#ret + 1] = {
+        title = vim.fn.fnamemodify(item.value, ":t"),
+        file = item.value,
+        icon = "file",
+        action = function()
+          vim.cmd("e " .. vim.fn.fnameescape(item.value))
+        end,
+        autokey = true,
+      }
+
+      if #ret >= limit then
+        break
+      end
+    end
+
+    return ret
+  end
+end
+
 --- Get the most recent projects based on git roots of recent files.
 --- The default action will change the directory to the project root,
 --- try to restore the session and open the picker if the session is not restored.


### PR DESCRIPTION
## Description
* Add a harpoon sections to the dashboard.lua file with an optional limit parameter. Only works for harpoon 2. 

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
I couldn't find any related issue. 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
<img width="500" alt="Screenshot 2025-04-29 at 10 48 29 PM" src="https://github.com/user-attachments/assets/f70b3511-328a-42f5-9c8b-f34ac1fcc316" />

<!-- Add screenshots of the changes if applicable. -->

This is my first ever open-source pull request. I would appreciate any feedback. Thank you 