### PR TITLE
fix(picker.lsp_symbols): the lsp_symbols picker now respects `icon_width`

### DIFF
--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -298,8 +298,8 @@ function M.lsp_symbol(item, picker)
   end
   local kind = item.kind or "Unknown" ---@type string
   local kind_hl = "SnacksPickerIcon" .. kind
-  ret[#ret + 1] = { picker.opts.icons.kinds[kind], kind_hl }
-  ret[#ret + 1] = { " " }
+  icon = Snacks.picker.util.align(picker.opts.icons.kinds[kind], picker.opts.formatters.file.icon_width or 2)
+  ret[#ret + 1] = { icon, kind_hl }
   local name = vim.trim(item.name:gsub("\r?\n", " "))
   name = name == "" and item.detail or name
   Snacks.picker.highlight.format(item, name, ret)

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -298,7 +298,7 @@ function M.lsp_symbol(item, picker)
   end
   local kind = item.kind or "Unknown" ---@type string
   local kind_hl = "SnacksPickerIcon" .. kind
-  icon = Snacks.picker.util.align(picker.opts.icons.kinds[kind], picker.opts.formatters.file.icon_width or 2)
+  icon = Snacks.picker.util.align(picker.opts.icons.kinds[kind], opts.formatters.file.icon_width or 2)
   ret[#ret + 1] = { icon, kind_hl }
   local name = vim.trim(item.name:gsub("\r?\n", " "))
   name = name == "" and item.detail or name


### PR DESCRIPTION
## Description

This PR applies the `picker.opts.formatters.file.icon_width` option to the lsp_symbols picker.

## Related Issue(s)

Fixes #1673

## Screenshots

![Screenshot 2025-05-02 at 12 58 14](https://github.com/user-attachments/assets/f9140981-c7dd-4c74-8e3a-9d5a84388026)

## Test

```lua
require("snacks").picker.pick({
	finder = "lsp_symbols",
	formatters = { file = { icon_width = 8 } },
	tree = true,
	filter = {
		default = true,
	},
})
```