### PR TITLE
docs(rename): fix oil.nvim example, add info about native LSP support

### DIFF
--- a/doc/snacks-rename.txt
+++ b/doc/snacks-rename.txt
@@ -37,16 +37,19 @@ LSP-integrated file renaming with support for plugins like neo-tree.nvim
 3. oil.nvim                                           *snacks-rename-oil.nvim*
 
 >lua
-    vim.api.nvim_create_autocmd("User", {
-      pattern = "OilActionsPost",
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "OilActionsPost",
       callback = function(event)
-          if event.data.actions.type == "move" then
-              Snacks.rename.on_rename_file(event.data.actions.src_url, event.data.actions.dest_url)
-          end
-      end,
-    })
+	for _, action in ipairs(event.data.actions) do
+	  if action.type == "move" then
+	    require("snacks").rename.on_rename_file(action.src_url, action.dest_url)
+	    end
+	  end
+	end,
+  })
 <
-
+Note: this functionality is also supported natively in oil
+(config.lsp_file_methods)
 
 ==============================================================================
 4. neo-tree.nvim                                 *snacks-rename-neo-tree.nvim*

--- a/docs/rename.md
+++ b/docs/rename.md
@@ -18,16 +18,22 @@ vim.api.nvim_create_autocmd("User", {
 
 ## [oil.nvim](https://github.com/stevearc/oil.nvim)
 
+
 ```lua
-vim.api.nvim_create_autocmd("User", {
-  pattern = "OilActionsPost",
-  callback = function(event)
-      if event.data.actions.type == "move" then
-          Snacks.rename.on_rename_file(event.data.actions.src_url, event.data.actions.dest_url)
-      end
-  end,
-})
+  vim.api.nvim_create_autocmd("User", {
+    pattern = "OilActionsPost",
+      callback = function(event)
+	for _, action in ipairs(event.data.actions) do
+	  if action.type == "move" then
+	    require("snacks").rename.on_rename_file(action.src_url, action.dest_url)
+	    end
+	  end
+	end,
+  })
 ```
+
+Note: this functionality is also supported natively in oil
+(config.lsp_file_methods).
 
 ## [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim)
 


### PR DESCRIPTION
## Description

The example of oil.nvim renaming integration doesn't work out of the box - `event.data.actions` is an array of actions which should be iterated over, otherwise the type key is always nil and the rename is never triggered. Also, it's probably worth mentioning that oil supports such LSP operations natively.

## Related Issue(s)


## Screenshots

