### PR TITLE
feat(picker): Add `default_args` file picker option

### DIFF
--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -1243,6 +1243,7 @@ FILES                                            *snacks-picker-sources-files*
     ---@field follow? boolean follow symlinks
     ---@field exclude? string[] exclude patterns
     ---@field args? string[] additional arguments
+    ---@field default_args? boolean Use default arguments (default: true)
     ---@field ft? string|string[] file extension(s)
     ---@field rtp? boolean search in runtimepath
     {
@@ -1253,6 +1254,7 @@ FILES                                            *snacks-picker-sources-files*
       ignored = false,
       follow = false,
       supports_live = true,
+      default_args = true,
     }
 <
 

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -1046,6 +1046,7 @@ Neovim commands
 ---@field follow? boolean follow symlinks
 ---@field exclude? string[] exclude patterns
 ---@field args? string[] additional arguments
+---@field default_args? boolean Use default arguments (default: true)
 ---@field ft? string|string[] file extension(s)
 ---@field rtp? boolean search in runtimepath
 {
@@ -1056,6 +1057,7 @@ Neovim commands
   ignored = false,
   follow = false,
   supports_live = true,
+  default_args = true,
 }
 ```
 

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -195,6 +195,7 @@ M.diagnostics_buffer = {
 ---@field follow? boolean follow symlinks
 ---@field exclude? string[] exclude patterns
 ---@field args? string[] additional arguments
+---@field default_args? boolean Use default arguments (default: true)
 ---@field ft? string|string[] file extension(s)
 ---@field rtp? boolean search in runtimepath
 M.files = {
@@ -205,6 +206,7 @@ M.files = {
   ignored = false,
   follow = false,
   supports_live = true,
+  default_args = true,
 }
 
 ---@class snacks.picker.git.Config: snacks.picker.Config

--- a/lua/snacks/picker/source/files.lua
+++ b/lua/snacks/picker/source/files.lua
@@ -57,6 +57,7 @@ local function get_cmd(opts, filter)
   if not cmd or not args then
     return
   end
+  if not opts.default_args then args = {} end
   local is_fd, is_fd_rg, is_find, is_rg = cmd == "fd" or cmd == "fdfind", cmd ~= "find", cmd == "find", cmd == "rg"
 
   -- exclude


### PR DESCRIPTION
## Description

I've added a `default_args` option to the file picker options with a default of `true`. This allows `default_args = false` to be passed along with a custom `args` table which passes all the necessary flags.

I've found a few uses where I wanted to use the builtin file picker rather than writing a custom `finder`, however I was limited by the need to use the builtin args. In particular the `-t f` assumes I'm always looking for files (naturally), but it makes it difficult to override with `-t d` to find directories only for example. (`fd` treats multiple `-t` flags as OR instead of overriding.)

Perhaps an alternative would be a flag that's more specific to the `-t`/`--type` flag. (Defaulting to `{ "f", "l" }` but being overridable with a string or a table of strings) This would potentially make more sense if it was very important that some of the default args always be passed to avoid issues. It would probably need to support `fd`, `rg`, and `find` then. 🤔