### PR TITLE
fix(scripts): Make scripts use /usr/bin/env shebang (support cross-platform)

### DIFF
--- a/scripts/docs
+++ b/scripts/docs
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/test
+++ b/scripts/test
@@ -1,3 +1,3 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 nvim -l tests/minit.lua --minitest


### PR DESCRIPTION
## Description

Tired of fixing this when running on MacOS 🙂

See https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability (`/usr/bin/env` is more universally present than `/bin/env`)

