### PR TITLE
feat(picker): tweak telescope layout

### DIFF
--- a/lua/snacks/picker/config/layouts.lua
+++ b/lua/snacks/picker/config/layouts.lua
@@ -57,7 +57,7 @@ M.telescope = {
     {
       win = "preview",
       title = "{preview:Preview}",
-      width = 0.45,
+      width = 0.5,
       border = "rounded",
       title_pos = "center",
     },


### PR DESCRIPTION
## Description
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Feature suggestion: Make the telescope picker symmetrical. I am all in for providing a layout that mostly replicates the overall feel of the telescope picker, but I am not sure why we would inherit the ever so slight asymmetries of it. There is also no good reasoning on why the ratio should be 55:45 vs 58:42 vs 60:40, etc. At this point it would make more sense to make it symmetrical by default, i.e. 50:50 and let users, who want something else, override it them self in their own config.

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots
<!-- Add screenshots of the changes if applicable. -->

### Before
![before](https://github.com/user-attachments/assets/be512308-b906-4484-9ee9-27842a9a4f7d)

### After
![after](https://github.com/user-attachments/assets/2a21dd96-a241-491e-81c3-d0a1cb1aefae)
