### PR TITLE
fix(explorer): added nil check on file for FreeBSD compatibility

### DIFF
--- a/lua/snacks/explorer/watch.lua
+++ b/lua/snacks/explorer/watch.lua
@@ -16,7 +16,11 @@ function M.start(path, cb)
   end
   local handle = assert(vim.uv.new_fs_event())
   local ok, err = handle:start(path, {}, function(_, file, events)
-    file = path .. "/" .. file
+    if file == nil then
+      file = path
+    else
+      file = path .. "/" .. file
+    end
     if cb then
       cb(file, events)
     else


### PR DESCRIPTION
## Description

NeoVim installations on FreeBSD using snacks.nvim can fail because a bug on OS file events and it can't be managed correctly by libuv.

A note about it exists in libuv documentation for [uv_fs_event_t](https://docs.libuv.org/en/v1.x/fs_event.html):

> For FreeBSD path could sometimes be NULL due to a kernel bug.

This patch will allow use snacks.nvim on FreeBSD more easily without make modifications to each installation.

## Related Issue(s)

None

## Screenshots

None

