### PR TITLE
docs: add shell-color-scripts as colorscript source for dashboard

### DIFF
--- a/doc/snacks-dashboard.txt
+++ b/doc/snacks-dashboard.txt
@@ -243,7 +243,8 @@ In the example below, both sections are equivalent.
 
 ADVANCED                                  *snacks-dashboard-examples-advanced*
 
-A more advanced example using multiple panes
+A more advanced example using multiple panes.
+Note: requires https://github.com/charitarthchugh/shell-color-scripts
 
 >lua
     {


### PR DESCRIPTION
Googling for `colorscript "-e" square` might otherwise lead users to download wrong repo with a similar name

  - Fixes (https://github.com/folke/snacks.nvim/discussions/226#discussion-7648569)
