### PR TITLE
fix: modified words.lua to use client:supports_method instead of client.supports_method as it is deprecated

### DIFF
--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -108,7 +108,7 @@ function M.is_enabled(opts)
   end
   local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = buf })
   clients = vim.tbl_filter(function(client)
-    return client.supports_method("textDocument/documentHighlight", { bufnr = buf })
+    return client:supports_method("textDocument/documentHighlight", { bufnr = buf })
   end, clients)
   return #clients > 0
 end


### PR DESCRIPTION
## Description

The client.supports_method on line 110 of words.lua is deprecated in newer versions of neovim (v0.11). I changed it to be client:supports_method as that is the new way for neovim

## Related Issue(s)

Only issue is the vim.deprecated message when loading up
