### PR TITLE
docs(picker): Fix typo in picker docs

### DIFF
--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -189,7 +189,7 @@ Snacks now comes with a modern fuzzy-finder to navigate the Neovim universe.
 - over 40 built-in sources <https://github.com/folke/snacks.nvim/blob/main/docs/picker.md#-sources>
 - Fast and powerful fuzzy matching engine that supports the fzf <https://junegunn.github.io/fzf/search-syntax/> search syntax
     - additionally supports field searches like `file:lua$ 'function`
-    - `files` and `grep` additionally support adding optiont like `foo -- -e=lua`
+    - `files` and `grep` additionally support adding options like `foo -- -e=lua`
 - uses **treesitter** highlighting where it makes sense
 - Sane default settings so you can start using it right away
 - Finders and matchers run asynchronously for maximum performance

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -14,7 +14,7 @@ Snacks now comes with a modern fuzzy-finder to navigate the Neovim universe.
 - 🔎 over 40 [built-in sources](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md#-sources)
 - 🚀 Fast and powerful fuzzy matching engine that supports the [fzf](https://junegunn.github.io/fzf/search-syntax/) search syntax
   - additionally supports field searches like `file:lua$ 'function`
-  - `files` and `grep` additionally support adding optiont like `foo -- -e=lua`
+  - `files` and `grep` additionally support adding options like `foo -- -e=lua`
 - 🌲 uses **treesitter** highlighting where it makes sense
 - 🧹 Sane default settings so you can start using it right away
 - 💪 Finders and matchers run asynchronously for maximum performance


### PR DESCRIPTION
## Description

Fix typo in snacks-picker docs. I've noticed the docs are auto-generated, so I split my changes into 2 commits so I can drop the change to the markdown file if preferred. Just let me know!

