### PR TITLE
fix: only run normal mode commands if not in terminal mode

### DIFF
--- a/lua/snacks/zen.lua
+++ b/lua/snacks/zen.lua
@@ -145,7 +145,10 @@ function M.zen(opts)
 
   -- create window
   local win = Snacks.win(win_opts)
-  vim.cmd([[norm! zz]])
+  -- Only run normal mode commands if not in terminal mode
+  if vim.bo[buf].buftype ~= "terminal" then
+    vim.cmd([[norm! zz]])
+  end
   M.win = win
 
   if show_indicator then


### PR DESCRIPTION

## Description

This PR fixes an issue where normal mode commands were being executed in terminal mode buffers. The change ensures that the command `norm! zz` is only executed if the buffer type is not "terminal". This prevents errors when using Zen mode with terminal buffers.

## Related Issue(s)

- Fixes #1911

## Screenshots

<!-- Add screenshots of the changes if applicable. -->