### PR TITLE
fix(image): do not save remote image if fetch fails

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -62,6 +62,9 @@ local commands = {
       local src = M.norm(ctx.src)
       return M.is_uri(src) and convert:tmpfile("data") or src
     end,
+    on_error = function(step)
+      vim.fs.rm(step.file)
+    end,
   },
   typ = {
     ft = "pdf",


### PR DESCRIPTION
## Description

If fetching an image fails, when the buffer with the image is opened again, the error message shown is for the `identify` command rather than the `url` command. This is because the output of the `wget` or `curl` command is saved to the file even if the fetching fails. Thus, when we try to resolve it again, we think it's cached and read the file on the `identify` step only to fail.

## Related Issue(s)

did not find any

