### PR TITLE
style(indent): fix typo `overlappping` → `overlapping`

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -301,7 +301,7 @@ local function bounds(scope, state)
   return from, to
 end
 
---- Render the scope overlappping the given range
+--- Render the scope overlapping the given range
 ---@param scope snacks.indent.Scope
 ---@param state snacks.indent.State
 ---@private


### PR DESCRIPTION
## Description
While debugging https://github.com/folke/snacks.nvim/issues/1808, I noticed a typo.
