### PR TITLE
fix(scope): allow user to disable keys

### DIFF
--- a/lua/snacks/scope.lua
+++ b/lua/snacks/scope.lua
@@ -774,14 +774,18 @@ end
 function M.setup()
   local keys = Snacks.config.get("scope", defaults).keys
   for key, opts in pairs(keys.textobject) do
-    vim.keymap.set({ "x", "o" }, key, function()
-      M.textobject(opts)
-    end, { silent = true, desc = opts.desc })
+    if opts then
+      vim.keymap.set({ "x", "o" }, key, function()
+        M.textobject(opts)
+      end, { silent = true, desc = opts.desc })
+    end
   end
   for key, opts in pairs(keys.jump) do
-    vim.keymap.set({ "n", "x", "o" }, key, function()
-      M.jump(opts)
-    end, { silent = true, desc = opts.desc })
+    if opts then
+      vim.keymap.set({ "n", "x", "o" }, key, function()
+        M.jump(opts)
+      end, { silent = true, desc = opts.desc })
+    end
   end
 end
 


### PR DESCRIPTION
## Description
Currently the user is not able to disable the existing keys in `keys.textobject`, because if he sets for example `ii = false`, it throws an error about not being able to index `opts`.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None, rather a LazyVim discussion https://github.com/LazyVim/LazyVim/discussions/6118
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

