### PR TITLE
fix(picker.actions): take into account if source is `recent` explicitly

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -266,23 +266,15 @@ function M.picker(picker, item, action)
   for _, p in ipairs(Snacks.picker.get({ source = source })) do
     p:close()
   end
-  if source == "recent" then
-    Snacks.picker(source, {
-      filter = {
-        cwd = Snacks.picker.util.dir(item),
-      },
-      on_show = function()
-        picker:close()
-      end,
-    })
-  else
-    Snacks.picker(source, {
-      cwd = Snacks.picker.util.dir(item),
-      on_show = function()
-        picker:close()
-      end,
-    })
-  end
+  Snacks.picker(source, {
+    cwd = Snacks.picker.util.dir(item),
+    filter = {
+      cwd = source == "recent" and Snacks.picker.util.dir(item) or nil,
+    },
+    on_show = function()
+      picker:close()
+    end,
+  })
 end
 
 M.picker_files = { action = "picker", source = "files" }


### PR DESCRIPTION
## Description
I noticed in the project picker that when pressing `<c-r>` to show recent files it showed recent files from everywhere instead of only the item's directory. When the source is `recent` we have to pass `filter.cwd = ...` so that it correctly filters out recent items.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

