### PR TITLE
feat(picker - format): enables icon alignment

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -148,6 +148,8 @@ local defaults = {
       truncate = 40, -- truncate the file path to (roughly) this length
       filename_only = false, -- only show the filename
       icon_width = 2, -- width of the icon (in characters)
+      ---@type {align?: "left" | "right" | "center", truncate?: boolean}
+      icon_align_opts = nil,
       git_status_hl = true, -- use the git status highlight group for the filename
     },
     selected = {

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -63,7 +63,15 @@ function M.filename(item, picker)
     if item.dir and item.open then
       icon = picker.opts.icons.files.dir_open
     end
-    icon = Snacks.picker.util.align(icon, picker.opts.formatters.file.icon_width or 2)
+    -- Adds padding to let icon take up 2 columns
+    if picker.opts.formatters.file.icon_align_opts and picker.opts.formatters.file.icon_width > 1 then
+      icon = icon .. " "
+    end
+    icon = Snacks.picker.util.align(
+      icon,
+      picker.opts.formatters.file.icon_width or 2,
+      picker.opts.formatters.file.icon_align_opts
+    )
     ret[#ret + 1] = { icon, hl, virtual = true }
   end
 


### PR DESCRIPTION
## Description
I wanted to use two icons for the directory to allow having a consistent icon for directory and to also represent an open/closed state with icons representing angle pointed left or down. E.g I'd like to have something similar to this [▷|▽] [🗂️] but this would indent folder icon further right while all other icons stay aligned left.
The goal is to allow icon alignment.

## Related Issue(s)

n/a

## Screenshots

![CleanShot 2025-06-01 at 00 02 17@2x](https://github.com/user-attachments/assets/f73ff58b-43ee-43a7-a735-359f7a107dfb)
