### PR TITLE
fix: Fixed the issue of dim's scope variable being nil and outputting…

### DIFF
--- a/lua/snacks/dim.lua
+++ b/lua/snacks/dim.lua
@@ -108,7 +108,9 @@ function M.enable(opts)
             buf = buf,
           }
         end
-
+        if scope == nil then
+          return
+        end
         Snacks.animate(scopes_anim[win].from, scope.from, function(v)
           if not scopes_anim[win] or not vim.api.nvim_win_is_valid(win) then
             return


### PR DESCRIPTION
## Description

During my use of dim, I found that an empty document can cause Snacks to output error messages, resulting in an instant freeze when opening an empty file

## Related Issue(s)

- Fixes #1810 

## Screenshots
before change
![before-fix-dim](https://github.com/user-attachments/assets/203791d7-629a-4650-9c87-a04fb81bad3d)


after change
![after-fix-dim](https://github.com/user-attachments/assets/44097f7d-2229-4407-8868-388e758774b5)


