### PR TITLE
fix(indent): prevent crash from invalid window ID in step()

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -393,7 +393,10 @@ end
 ---@param prev? number
 local function step(scope, value, prev)
   prev = prev or 0
-  local cursor = vim.api.nvim_win_get_cursor(scope.win)
+  local ok, cursor = pcall(vim.api.nvim_win_get_cursor, scope.win)
+  if not ok then
+    return
+  end
   local dt = math.abs(scope.from - cursor[1])
   local db = math.abs(scope.to - cursor[1])
   local style = config.animate.style == "up_down" and (dt < db and "down" or "up") or config.animate.style


### PR DESCRIPTION
The step() function in snacks.indent crashes when using Harpoon to switch buffers. This is caused by nvim_win_get_cursor receiving an invalid window ID (scope.win), likely due to a delayed scheduled callback.

Wrapped the call in pcall() to prevent the crash.

## Description

The file buffer when open for the first time using Harpoon (especially when the file has embedded languages, like HTML + JS or Markdown + C) causes vim.scheduler error in the snacks.indent.step().
This happens because the when the buffer is loaded Harpoon quickly closes/switches it, so that it can be used using Harpoon keybindings, hence the window ID becomes invalid. The scheduled step animation now crashes which is not handled well.

### Steps to recreate the problem
1. Create a simple markdown file with embedded code (or, any other file with embedded code), add it to the Harpoon menu, and close the editor.
3. Now open NeoVim using the command 'nvim'
4. Use Harpoon to move to the buffer via, leader + 1.
5. Error is thrown:
```
Error executing vim.schedule lua callback: ....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:396: Invalid window id: 1001
stack traceback:
	[C]: in function 'nvim_win_get_cursor'
	....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:396: in function 'step'
	....local/share/nvim/lazy/snacks.nvim/lua/snacks/indent.lua:436: in function 'cb'
	.../.local/share/nvim/lazy/snacks.nvim/lua/snacks/scope.lua:610: in function 'cb'
	.../.local/share/nvim/lazy/snacks.nvim/lua/snacks/scope.lua:562: in function 'get'
	.../.local/share/nvim/lazy/snacks.nvim/lua/snacks/scope.lua:500: in function 'cb'
	...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:478: in function '_run_async_callbacks'
	...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:534: in function <...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:513>
```

__Expected:__ No error, even if the window ID becomes invalid during scheduled callbacks.
__Actual:__ Crash due to unprotected call to nvim_win_get_cursor() on an invalid window ID.
__Fix:__ Wrap the call in pcall() to safely handle the case where the window no longer exists.

## Related Issue(s)

None

## Screenshots

![HTML file](https://github.com/user-attachments/assets/1b87ed7a-8291-4119-bc5b-1bfaecdd6de9)
_In this HTML file, the script tag is embedding the JavaScript._
