### PR TITLE
fix(image): images not being inlined inside tmux

### DIFF
--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -31,6 +31,8 @@ local environments = {
   {
     name = "tmux",
     env = { TERM = "tmux", TMUX = true },
+    supported = true,
+    placeholders = true,
     setup = function()
       pcall(vim.fn.system, { "tmux", "set", "-p", "allow-passthrough", "all" })
     end,


### PR DESCRIPTION
## Description
  
Currently images are not properly aligned in tmux, and floating mode is the only mode available. This minor change enables that.
 
 ```
 ~
❮ kitty --version
kitty 0.40.0 created by Kovid Goyal

~
❮ tmux -V
tmux 3.5a

~
❮ nvim --version
NVIM v0.11.0
Build type: Release
LuaJIT 2.1.1741730670
Run "nvim -V1 -v" for more info
 ```

## Screenshots


https://github.com/user-attachments/assets/f43d2fcd-804a-4664-9fc1-704bc6c83d77


https://github.com/user-attachments/assets/a589915b-19b3-4c11-8af2-ffadd8294003