### PR TITLE
fix(image): option to enable images in 256 color term

### DIFF
--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -39,6 +39,7 @@ M.meta = {
 
 ---@class snacks.image.Config
 ---@field enabled? boolean enable image viewer
+---@field cterm256? boolean use 256 colors for image ids
 ---@field wo? vim.wo|{} options for windows showing the image
 ---@field bo? vim.bo|{} options for the image buffer
 ---@field formats? string[]

--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -203,12 +203,16 @@ end
 --- Renders the unicode placeholder grid in the buffer
 ---@param loc snacks.image.Loc
 function M:render_grid(loc)
+  local bit = require("bit")
+  local upper_id = bit.band(bit.rshift(self.img.id, 24), 0xff)
+
   local hl = "SnacksImage" .. self.id -- image id is encoded in the foreground color
   Snacks.util.set_hl({
     [hl] = {
-      fg = self.img.id,
+      fg = bit.band(self.img.id, 0xffffff),
       sp = self.id,
       bg = Snacks.image.config.debug.placement and "#FF007C" or "none",
+      ctermfg = bit.band(self.img.id, 0xff),
       nocombine = true,
     },
   })
@@ -222,6 +226,9 @@ function M:render_grid(loc)
       line[#line + 1] = PLACEHOLDER
       line[#line + 1] = positions[r]
       line[#line + 1] = positions[c]
+      if upper_id > 0 then
+        line[#line + 1] = positions[upper_id + 1]
+      end
     end
     img[#img + 1] = table.concat(line)
   end


### PR DESCRIPTION
## Description

Image package only uses 24-bit color to provide image id via kitty protocol. This adds support for 8-bit cterm (256 colors) by utilising foreground color of a diacritic. But since there are only 8-bit available for image ids this way, it's better to use the thrid diacritic to extend the id range by another 8-bits.

https://sw.kovidgoyal.net/kitty/graphics-protocol/#unicode-placeholders:
> By using only the foreground color for image ID you are limited to either 8-bit IDs in 256 color mode or 24-bit IDs in true color mode. Since IDs are in a global namespace there can easily be collisions. If you need more bits for the image ID, you can specify the most significant byte via a third diacritic. For example, this is the placeholder for the image ID 33554474 = 42 + (2 << 24):
> 
> ```
> printf "\e[38;5;42m\U10EEEE\U0305\U0305\U030E\U10EEEE\U0305\U030D\U030E\n"
> printf "\e[38;5;42m\U10EEEE\U030D\U0305\U030E\U10EEEE\U030D\U030D\U030E\n"
> ```
>
> Here, U+30E is the diacritic corresponding to the number 2.

Tested in Ghostty.