### PR TITLE
fix(image): better resizing to keep ratio of original image

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -442,7 +442,7 @@ function M:state()
 
   -- scale down to fit inline
   if size.height <= 2 and is_inline() then
-    size.width = math.ceil(size.width / size.height) + 2
+    size.width = math.floor(size.width / size.height + 0.5)
     size.height = 1
   end
 

--- a/lua/snacks/image/util.lua
+++ b/lua/snacks/image/util.lua
@@ -38,9 +38,11 @@ end
 ---@param size snacks.image.Size
 ---@return snacks.image.Size
 function M.norm(size)
+  local normed_height = math.max(1, math.floor(size.height + 0.6)) -- TODO(yuukibarns): expose a threshold option
+  local normed_width = math.max(1, math.floor(normed_height * size.width / size.height + 0.5))
   return {
-    width = math.max(1, math.ceil(size.width)),
-    height = math.max(1, math.ceil(size.height)),
+    height = normed_height,
+    width = normed_width,
   }
 end
 


### PR DESCRIPTION
Problem:  The current implementation of normalize the pixel size to cell
          size applies `math.ceil()` to both `height` and `width` but if
          `height` is a little larger than 1 then it will be converted to
          2 and usually `width` is much larger than `height`, so `width`
          is roughly unchnaged, resulting in ratio x2, which makes the
          image quite narrow.

Solution: Apply `math.floor(x+0.5)` to `height` first and then calculate
          normed width by multiply the normed height with the original
          ratio.

TODO:     Since the dimensions of terminal cells varies, I think we can
          expose a threshold option for better normalization control.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

