### PR TITLE
feat(picker.git): allow passing extra args to git log command for file renames

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -134,7 +134,17 @@ function M.log(opts, ctx)
       Proc.proc({
         cmd = "git",
         cwd = cwd,
-        args = { "log", "-z", "--follow", "--name-status", "--pretty=format:''", "--diff-filter=R", "--", file },
+        args = git_args(
+          opts.args,
+          "log",
+          "-z",
+          "--follow",
+          "--name-status",
+          "--pretty=format:''",
+          "--diff-filter=R",
+          "--",
+          file
+        ),
       }, ctx)(function(item)
         for _, text in ipairs(vim.split(item.text, "\0")) do
           if text:find("^R%d%d%d$") then


### PR DESCRIPTION
## Description

Allows passing extra Git arguments (like `--git-dir` or `--work-tree`) to the rename detection logic inside `M.log` in `picker/source/git.lua`.

Previously, these extra arguments from `opts.args` were applied to the main `git log` command but ignored during rename detection. This caused errors or incorrect results when working in non-standard repo setups.

This change uses `git_args(...)` to build the rename detection command, ensuring consistent argument handling throughout `M.log`.