### PR TITLE
fix(bigfile): bigfile doesn't work on windows.

### DIFF
--- a/lua/snacks/bigfile.lua
+++ b/lua/snacks/bigfile.lua
@@ -40,7 +40,7 @@ function M.setup()
           if not path or not buf or vim.bo[buf].filetype == "bigfile" then
             return
           end
-          if path ~= vim.api.nvim_buf_get_name(buf) then
+          if path ~= vim.fs.normalize(vim.api.nvim_buf_get_name(buf)) then
             return
           end
           local size = vim.fn.getfsize(path)


### PR DESCRIPTION
## Description

`bigfile` checks whether the path and the buffer name are identical in filetype detection, but on windows, the path separator might be different. The buffer name should be normalized here.

## Related Issue

Fixes #1722

