### PR TITLE
fix(picker): remove self:attach() recursive call from M:init_layout()

### DIFF
--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -268,7 +268,6 @@ function M:init_layout(layout)
       backdrop = backdrop,
     },
   }))
-  self:attach()
 
   -- apply box highlight groups
   local boxwhl = Snacks.picker.highlight.winhl("SnacksPickerBox")
@@ -284,6 +283,7 @@ function M:attach()
   -- Check if we need to load another layout
   self.layout.root:on("VimResized", function()
     vim.schedule(function()
+      -- vim.print(Snacks.picker.config.layout(self.opts))
       self:set_layout(Snacks.picker.config.layout(self.opts))
     end)
   end)

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -283,7 +283,6 @@ function M:attach()
   -- Check if we need to load another layout
   self.layout.root:on("VimResized", function()
     vim.schedule(function()
-      -- vim.print(Snacks.picker.config.layout(self.opts))
       self:set_layout(Snacks.picker.config.layout(self.opts))
     end)
   end)


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  
 Remove infinitely looping recursive `self:attach()` call from `M:init_layout()` , which was causing neovim to crash on `VimResized` event.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.

-->
  - Fixes #1913 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

