### PR TITLE
feat: add setting to disable root level indent and scope

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -17,6 +17,7 @@ local defaults = {
     only_scope = false, -- only show indent guides of the scope
     only_current = false, -- only show indent guides in the current window
     hl = "SnacksIndent", ---@type string|string[] hl groups for indent guides
+    skip_root_level = false, -- skip root level indent
     -- can be a list of hl groups to cycle through
     -- hl = {
     --     "SnacksIndent1",
@@ -55,6 +56,7 @@ local defaults = {
     underline = false, -- underline the start of the scope
     only_current = false, -- only show scope in the current window
     hl = "SnacksIndentScope", ---@type string|string[] hl group for scopes
+    skip_root_level = false, -- skip root level scope
   },
   chunk = {
     -- when enabled, scopes will be rendered as chunks, except for the
@@ -158,7 +160,9 @@ local function get_extmarks(indent, state)
 
   for i = 1 + offset, indent do
     local col = (i - 1) * sw - state.leftcol
-    if col >= 0 then
+    local col_threshold = config.indent.skip_root_level and 1 or 0
+
+    if col >= col_threshold then
       table.insert(cache_extmarks[key], {
         virt_text = { { config.indent.char, get_hl(i, config.indent.hl) } },
         virt_text_pos = "overlay",
@@ -321,8 +325,9 @@ function M.render_scope(scope, state)
       ephemeral = true,
     })
   end
+  local col_threshold = config.scope.skip_root_level and 1 or 0
 
-  if col < 0 then -- scope is hidden
+  if col < col_threshold then -- scope is hidden
     return
   end
 


### PR DESCRIPTION
## Description

This small change allows to skip root level indent/scope highlight, since some (like me) don't see much value in it. It also helps to reduce noise and cognitive load.

## Related Issue(s)

- Fixes https://github.com/folke/snacks.nvim/issues/1537

## Screenshots

![image](https://github.com/user-attachments/assets/8ec88d98-e160-4b04-967c-35e07ba2c81b)

