### PR TITLE
fix(util): fix invalid window error

### DIFF
--- a/lua/snacks/util/init.lua
+++ b/lua/snacks/util/init.lua
@@ -203,7 +203,7 @@ end
 ---@param from number -- 1-indexed, inclusive
 ---@param to number -- 1-indexed, inclusive
 function M.redraw_range(win, from, to)
-  if vim.api.nvim__redraw then
+  if vim.api.nvim__redraw and vim.api.nvim_win_is_valid(win) then
     vim.api.nvim__redraw({ win = win, range = { math.floor(from - 1), math.floor(to) }, valid = true, flush = false })
   else
     vim.cmd([[redraw!]])


### PR DESCRIPTION
## Description

Add check if win id is valid to prevent errors when opening buffers using Harpoon, or Diffview.

## Related Issue(s)

- Fixes #1968

## Screenshots

<img width="1391" alt="image" src="https://github.com/user-attachments/assets/daa8cbd1-7104-4c5d-8cae-d50a900b6c76" />

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/6dd9cae6-fc3f-4a5e-b5ae-6fc1e4afeeca" />


