### PR TITLE
fix(dashboard): the absence of matchparen make a bad cursor position

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -717,7 +717,7 @@ function D:update()
 
   -- cursor movement
   local last = { 1, 0 }
-  vim.api.nvim_create_autocmd("CursorMoved", {
+  vim.api.nvim_create_autocmd({ "CursorMoved", "TextChanged" }, {
     group = vim.api.nvim_create_augroup("snacks_dashboard_cursor", { clear = true }),
     buffer = self.buf,
     callback = function()


### PR DESCRIPTION
## Description

I have a bad cursor position when I enter to the dashboard because I disabled `matchparen` default plugin from `lazy.nvim` in favor of `matchparen.nvim` because is so fast than default one.

![CursorTopLeft](https://github.com/user-attachments/assets/62281130-34cb-4a6d-8ec3-700ef993b423)

So I fixed in a single line with this pull request, maybe is not the only or the right way, you can fix if is not

Now has the right position.

![CursorRightPosition](https://github.com/user-attachments/assets/c9619308-022b-4878-a01d-9cb688c7822d)

Thanks.

