### PR TITLE
Fix get_root default path

### DIFF
--- a/lua/snacks/git.lua
+++ b/lua/snacks/git.lua
@@ -27,7 +27,7 @@ end
 ---@param path? number|string buffer or path
 ---@return string?
 function M.get_root(path)
-  path = path or 0
+  path = path or (vim.uv or vim.loop).cwd() or 0
   path = type(path) == "number" and vim.api.nvim_buf_get_name(path) or path --[[@as string]]
   path = svim.fs.normalize(path)
   path = path == "" and (vim.uv or vim.loop).cwd() or path


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
`Snacks.git.get_root()` was returning the project directory of the currently active buffer, when it should be returning the project directory of the current working directory.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
Fixes #2008 

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

