### PR TITLE
fix: select correct window when closing picker

### DIFF
--- a/lua/snacks/picker/core/main.lua
+++ b/lua/snacks/picker/core/main.lua
@@ -19,7 +19,6 @@ function M.new(opts)
   local self = setmetatable({}, M)
   self.opts = opts
   self.win = vim.api.nvim_get_current_win()
-  self.win = self:find()
   return self
 end
 


### PR DESCRIPTION
## Description

Hi @folke, thanks for the amazing collection of plugins!

This PR fixes the bug that the incorrect window is focuses after closing a picker. This bug leads for example to pasting a register content into the incorrect buffer.

## Related Issue(s)

- partially addresses #1941