### PR TITLE
fix(picker): do not record consecutive duplicate history

### DIFF
--- a/lua/snacks/picker/util/history.lua
+++ b/lua/snacks/picker/util/history.lua
@@ -53,6 +53,10 @@ function M:is_current()
 end
 
 function M:record(value)
+  -- don't record value if it's identical to the last recorded value
+  if vim.deep_equal(self.kv:get(math.max(self.idx - 1, 1)), value) then
+    return
+  end
   self.kv:set(self.idx, value)
 end
 


### PR DESCRIPTION
## Description

Before this fix, identical items are added to history repeatedly. This PR fixes this by only adding an item to history if it's different from the last recorded value.

This doesn't completely remove duplicate entries in the history, it only prevents consecutive identical entries.