### PR TITLE
feat(picker.grep): Also ignore .bare git files

### DIFF
--- a/lua/snacks/picker/source/grep.lua
+++ b/lua/snacks/picker/source/grep.lua
@@ -16,7 +16,8 @@ local function get_cmd(opts, filter)
     "--max-columns=500",
     "--max-columns-preview",
     "-g",
-    "!.git",
+    "--glob=!.bare",
+    "--glob=!.git",
   }
 
   args = vim.deepcopy(args)


### PR DESCRIPTION
## Description

If you clone with --bare then you have a `.bare` and not a `.git` directory.