### PR TITLE
fix(gitbrowse): GitLab code highlighting

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -56,8 +56,8 @@ local defaults = {
     },
     ["gitlab%.com"] = {
       branch = "/-/tree/{branch}",
-      file = "/-/blob/{branch}/{file}#L{line_start}-L{line_end}",
-      permalink = "/-/blob/{commit}/{file}#L{line_start}-L{line_end}",
+      file = "/-/blob/{branch}/{file}#L{line_start}-{line_end}",
+      permalink = "/-/blob/{commit}/{file}#L{line_start}-{line_end}",
       commit = "/-/commit/{commit}",
     },
     ["bitbucket%.org"] = {


### PR DESCRIPTION
## Description

GitLab highlighting uses a different scheme for range of lines
https://gitlab.com/gitlab-org/gitlab/-/blob/fb2f3ce787ff4836ba827396ad30e89271711109/app/assets/javascripts/repository/mixins/highlight_mixin.js#L114

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

