### PR TITLE
fix(image): remove the image queue, which breaks images in *Ghostty* when we view images remotely, as chunks after the first one can get truncated

### DIFF
--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -51,19 +51,6 @@ vim.api.nvim_create_autocmd("VimResized", {
   end,
 })
 
--- HACK: ghostty doesn't like it when sending images too fast,
--- after Neovim startup, so we delay the first image
-local queue = {} ---@type string[]?
-vim.defer_fn(
-  vim.schedule_wrap(function()
-    for _, data in ipairs(queue or {}) do
-      io.stdout:write(data)
-    end
-    queue = nil
-  end),
-  100
-)
-
 function M.size()
   if size then
     return size
@@ -185,20 +172,12 @@ function M.request(opts)
   if Snacks.image.config.debug.request and opts.m ~= 1 then
     Snacks.debug.inspect(opts)
   end
-  M.write(data)
+  io.stdout:write(data)
 end
 
 ---@param pos {[1]: number, [2]: number}
 function M.set_cursor(pos)
-  M.write("\27[" .. pos[1] .. ";" .. (pos[2] + 1) .. "H")
-end
-
-function M.write(data)
-  if queue then
-    table.insert(queue, data)
-  else
-    io.stdout:write(data)
-  end
+  io.stdout:write("\27[" .. pos[1] .. ";" .. (pos[2] + 1) .. "H")
 end
 
 return M


### PR DESCRIPTION
## Description

Fixes a bug where remote images don't show up in *Ghostty*, and possibly other terminal emulators.

## Related Issue(s)

Fixes #1785.

## Screenshots

N/A.