### PR TITLE
docs(picker): add examples for picking from different file paths

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -595,6 +595,35 @@ Snacks.picker.pick({source = "files", ...})
 }
 ```
 
+### Search Different File Paths
+
+```lua
+-- All of these examples fallback to using neovim's CWD
+
+-- Pick files from native LSP's current root_dir
+function pick_lsp_root_files()
+  Snacks.picker.files({ cwd = vim.lsp.client.root_dir })
+end
+
+-- Pick files in the current git repo
+function pick_lsp_git_files()
+  if Snacks.git.get_root() then
+    return Snacks.picker.git_files({ untracked = true })
+  end
+  Snacks.picker.files({})
+end
+
+-- Pick files in the parent directory of the current buffer
+function pick_buffer_cwd_files()
+  local bufinfo = vim.fn.getbufinfo(0)[1]
+  local cwd = nil
+  if bufinfo.name:match("^/") then
+    cwd = vim.fs.dirname(bufinfo.name)
+  end
+  Snacks.picker.files({ cwd = cwd })
+end
+```
+
 ## 📚 Types
 
 ```lua


### PR DESCRIPTION
## Description

I find these different pickers useful, and they all work with just snacks + native neovim apis.
The only one that may cause issues is the LSP one if you haven't migrated to native LSP yet.

This should be an easy copy/paste example for most people to add to their config.
I can reformat it to be a lazy.nvim keys table if you'd like.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<img width="1148" height="1106" alt="image" src="https://github.com/user-attachments/assets/cdbfe4c5-1adc-486b-a08c-b736b4b31ac3" />

<!-- Add screenshots of the changes if applicable. -->

