### PR TITLE
feat(picker): add resumable support

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -71,6 +71,7 @@ local M = {}
 ---@field live? boolean when true, typing will trigger live searches
 ---@field limit? number when set, the finder will stop after finding this number of items. useful for live searches
 ---@field ui_select? boolean set `vim.ui.select` to a snacks picker
+---@field resumable? boolean when true, picker resumable with `Snacks.picker.resume()`
 --- Source definition
 ---@field items? snacks.picker.finder.Item[] items to show instead of using a finder
 ---@field format? string|snacks.picker.format|string format function or preset
@@ -138,6 +139,7 @@ local defaults = {
     fields = { "score:desc", "#text", "idx" },
   },
   ui_select = true, -- replace `vim.ui.select` with the snacks picker
+  resumable = true, -- resumable with `Snacks.picker.resume()`
   ---@class snacks.picker.formatters.Config
   formatters = {
     text = {

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -673,14 +673,18 @@ function M:close()
   for toggle in pairs(self.opts.toggles) do
     self.init_opts[toggle] = self.opts[toggle]
   end
-  M.last = {
-    opts = self.init_opts or {},
-    selected = self:selected({ fallback = false }),
-    cursor = self.list.cursor,
-    topline = self.list.top,
-    filter = self.input.filter,
-  }
-  M.last.opts.live = self.opts.live
+
+  if self.opts.resumable then
+    M.last = {
+      opts = self.init_opts or {},
+      selected = self:selected({ fallback = false }),
+      cursor = self.list.cursor,
+      topline = self.list.top,
+      filter = self.input.filter,
+    }
+    M.last.opts.live = self.opts.live
+  end
+
 
   local current = vim.api.nvim_get_current_win()
   local is_picker_win = vim.tbl_contains({ self.input.win.win, self.list.win.win, self.preview.win.win }, current)


### PR DESCRIPTION
## Description

Add an option resumable = true | false to picker options, define pickers you don't want to open with `Snacks.picker.resume()`.

## Related Issue(s)

- Fixes #1530

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

