### PR TITLE
fix grep parsing: filename can't contain a colon

### DIFF
--- a/test.text
+++ b/test.text
@@ -1,2 +1,0 @@
-0:0:0:0 foo
-leading text 0:0:0:0 bar


### PR DESCRIPTION
## Description
The regular expression was allowing the filename to contain colons which caused it to incorrectly match when lines contained a set of colon-separated numbers in the text itself.  I excluded colons from the allowed filenamelf.  This works for me in linux, but I don't have a windows machine to test on. I don't know how ripgrep outputs the filenames in Windows. If they contain the drive letter then this fix won't work, we'd need to allow for the preceding drive letter and colon.

## Related Issue(s)
https://github.com/folke/snacks.nvim/issues/2123



