### PR TITLE
feat(git): detect root dirs of git submodules

### DIFF
--- a/lua/snacks/git.lua
+++ b/lua/snacks/git.lua
@@ -38,9 +38,11 @@ function M.get_root(path)
   end
 
   -- check cache first
-  for _, dir in ipairs(todo) do
-    if git_cache[dir] then
-      return svim.fs.normalize(dir) or nil
+  if git_cache[path] ~= nil then
+    for _, dir in ipairs(todo) do
+      if git_cache[dir] then
+        return svim.fs.normalize(dir) or nil
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Current cache implementation does not work well to detect root directories of git submodules.
Here is an example. When I opened `superproject/src/super.txt`, there were 3 entries recorded in cache: `["superproject/src/super.txt"] = false`, `["superproject/src"] = false`, and `["superproject"] = true`. Next, `superproject/subproject/src/sub.txt` is opened. The cache `["superproject"]` is hit because the cache is checked first. However, `superproject/subproject` is what we looking for.
```
superproject/
├── .git
├── src/
│   └── super.txt
└── subproject/
    ├── .git
    └── src/
        └── sub.txt
```

My solution is making the cache lookup be skipped when the entry is not in the cache, i.e., the state is `nil`. If we open a new path which is not in the cache, all uncached parents and the path will be examined and pushed into cache.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

