### PR TITLE
docs(rename): netrw example

### DIFF
--- a/docs/rename.md
+++ b/docs/rename.md
@@ -78,10 +78,10 @@ vim.api.nvim_create_autocmd({ 'FileType' }, {
 
       vim.ui.input({ prompt = 'Move/rename to:', default = original_file_path }, function(target_file_path)
         if target_file_path and target_file_path ~= "" then
-          local file_exists = vim.loop.fs_access(target_file_path, "W")
+          local file_exists = vim.uv.fs_access(target_file_path, "W")
 
           if not file_exists then
-            vim.loop.fs_rename(original_file_path, target_file_path)
+            vim.uv.fs_rename(original_file_path, target_file_path)
 
             Snacks.rename.on_rename_file(original_file_path, target_file_path)
           else


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

I recently got really into improving my experience with netrw, in one of those explorations I managed to integrate with the `Snacks.rename` module by remapping the default rename mapping. So I thought it would be cool to include a more native approach to the documentation of this module.

> PS: In the example I implemented with the `vim.ui.input` interface since it should be the new standard, but if you prefer with the original `vim.fn.input` I can change it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

N/a

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

[![asciicast](https://asciinema.org/a/735692.svg)](https://asciinema.org/a/735692)