### PR TITLE
fix(terminal): set buffer when opening terminal with position='current'

### DIFF
--- a/docs/win.md
+++ b/docs/win.md
@@ -54,7 +54,7 @@ Snacks.win({
 ---@field col? number|fun(self:snacks.win):number Column of the window. Use <1 for relative column. (default: center)
 ---@field row? number|fun(self:snacks.win):number Row of the window. Use <1 for relative row. (default: center)
 ---@field minimal? boolean Disable a bunch of options to make the window minimal (default: true)
----@field position? "float"|"bottom"|"top"|"left"|"right"
+---@field position? "float"|"bottom"|"top"|"left"|"right"|"current"
 ---@field border? "none"|"top"|"right"|"bottom"|"left"|"hpad"|"vpad"|"rounded"|"single"|"double"|"solid"|"shadow"|string[]|false
 ---@field buf? number If set, use this buffer instead of creating a new one
 ---@field file? string If set, use this file instead of creating a new buffer

--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -63,7 +63,7 @@ M.meta = {
 ---@field col? number|fun(self:snacks.win):number Column of the window. Use <1 for relative column. (default: center)
 ---@field row? number|fun(self:snacks.win):number Row of the window. Use <1 for relative row. (default: center)
 ---@field minimal? boolean Disable a bunch of options to make the window minimal (default: true)
----@field position? "float"|"bottom"|"top"|"left"|"right"
+---@field position? "float"|"bottom"|"top"|"left"|"right"|"current"
 ---@field border? "none"|"top"|"right"|"bottom"|"left"|"hpad"|"vpad"|"rounded"|"single"|"double"|"solid"|"shadow"|string[]|false
 ---@field buf? number If set, use this buffer instead of creating a new one
 ---@field file? string If set, use this file instead of creating a new buffer
@@ -700,6 +700,7 @@ function M:open_win()
     self.win = vim.api.nvim_open_win(self.buf, enter, opts)
   elseif position == "current" then
     self.win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(self.win, self.buf)
   else
     local parent = self.opts.win or 0
     local vertical = position == "left" or position == "right"

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -23,3 +23,25 @@ describe("terminal.parse", function()
     end)
   end
 end)
+
+describe("terminal.open", function()
+  it("should set buffer when position is 'current'", function()
+    -- Create a test buffer with content
+    vim.cmd("enew")
+    local test_buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(test_buf, 0, -1, false, {"test content"})
+    
+    -- Open terminal with position='current'
+    local term = terminal.open(nil, { win = { position = "current" } })
+    
+    -- Check that the current window now has the terminal buffer
+    local current_win = vim.api.nvim_get_current_win()
+    local current_buf = vim.api.nvim_win_get_buf(current_win)
+    
+    assert.are.equal(term.buf, current_buf, "Terminal buffer should be set in current window")
+    assert.are.equal("terminal", vim.bo[current_buf].buftype, "Buffer should be a terminal")
+    
+    -- Clean up
+    term:close()
+  end)
+end)


### PR DESCRIPTION
## Description

When opening a terminal with position='current', the terminal buffer wasn't being set in the current window, causing the original buffer content to remain visible with terminal styling applied.

This fix adds a call to vim.api.nvim_win_set_buf() to properly set the terminal buffer when using position='current'. Also updates type annotations to include the 'current' position option and adds tests to prevent regression.

Credit to the solution to by @Baricus in issue #2148.

## Related Issue(s)

Fixes #2148