### PR TITLE
feat(bigfile): disable mini-hipatterns

### DIFF
--- a/lua/snacks/bigfile.lua
+++ b/lua/snacks/bigfile.lua
@@ -21,6 +21,7 @@ local defaults = {
     end
     Snacks.util.wo(0, { foldmethod = "manual", statuscolumn = "", conceallevel = 0 })
     vim.b.minianimate_disable = true
+    vim.b.minihipatterns_disable = true
     vim.schedule(function()
       if vim.api.nvim_buf_is_valid(ctx.buf) then
         vim.bo[ctx.buf].syntax = ctx.ft


### PR DESCRIPTION
## Description

The `mini.hipatterns` plugin causes slowdowns on big files. It's a great candidate for disabling along with `mini.animate`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->