### PR TITLE
fix(git): set `diff.noprefix=false` for `git diff` to ensure correct format

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -212,7 +212,9 @@ end
 ---@param opts snacks.picker.git.Config
 ---@type snacks.picker.finder
 function M.diff(opts, ctx)
-  local args = git_args(opts.args, "--no-pager", "diff", "--no-color", "--no-ext-diff")
+  local args = git_args(opts.args,
+    "-c", "diff.noprefix=false",
+    "--no-pager", "diff", "--no-color", "--no-ext-diff")
   local file, line ---@type string?, number?
   local header, hunk = {}, {} ---@type string[], string[]
   local header_len = 4


### PR DESCRIPTION
## Description

Parsing the output of git diff here depends on its exact format. The user environment might be set up with diff.noprefix, in which case the parsing fails, because the `a/` and `b/` prefixes for the paths is missing. Passing `-c diff.noprefix=false` to the call overrides this.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

