### PR TITLE
fix(git): invoke `git status` with `--no-optional-locks`

### DIFF
--- a/lua/snacks/explorer/git.lua
+++ b/lua/snacks/explorer/git.lua
@@ -61,6 +61,7 @@ function M.update(cwd, opts)
     hide = true,
     args = {
       "--no-pager",
+      "--no-optional-locks",
       "status",
       "--porcelain=v1",
       "--ignored=matching",


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
According to the Git docs, `git status` automatically refreshes the index, meaning it recreates the `.git/index` file. In `watch.lua`, we specifically watch for modifications of that file and (indirectly?) run `git status` everytime it changes. This effectively forms an infinite loop of refreshes whenever the explorer is open.

Passing `--no-optional-locks` to `git status` breaks this loop because it stops it from refreshing the index. Doing this also happens to be the official recommendation for scripts doing `git status` in the background: https://git-scm.com/docs/git-status#_background_refresh

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

