### PR TITLE
fix(words.lua): client.supports... (deprecated) -> client:suppo…

### DIFF
--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -108,7 +108,7 @@ function M.is_enabled(opts)
   end
   local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = buf })
   clients = vim.tbl_filter(function(client)
-    return client.supports_method("textDocument/documentHighlight", { bufnr = buf })
+    return client:supports_method("textDocument/documentHighlight", { bufnr = buf })
   end, clients)
   return #clients > 0
 end


### PR DESCRIPTION
client.support... (Deprecated) usually comes out inside Nvim while using the plugin, changes on this line fixes it.
<img width="808" height="95" alt="image" src="https://github.com/user-attachments/assets/79d9fb1b-06a4-4da0-b045-08476f8ba670" />