### PR TITLE
fix(words.lua): update client.supports... (deprecated) -> client:supports…

### DIFF
--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -108,7 +108,7 @@ function M.is_enabled(opts)
   end
   local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = buf })
   clients = vim.tbl_filter(function(client)
-    return client.supports_method("textDocument/documentHighlight", { bufnr = buf })
+    return client:supports_method("textDocument/documentHighlight", { bufnr = buf })
   end, clients)
   return #clients > 0
 end


### PR DESCRIPTION
Title: fix(words.lua): client.supports... (deprecated) -> client:support…
Description: Fixes nvim deprecation error.

This occurs on Latest version of Nvim (NVIM v0.12.0-dev)

<img width="808" height="95" alt="image" src="https://github.com/user-attachments/assets/d762f25e-3c99-4ce6-b464-68b881f00bc5" />
