### PR TITLE
docs(mini): update URLs for nvim-mini related plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A collection of small QoL plugins for Neovim.
 | [picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md) | Picker for selecting items | ‼️ |
 | [profiler](https://github.com/folke/snacks.nvim/blob/main/docs/profiler.md) | Neovim lua profiler |  |
 | [quickfile](https://github.com/folke/snacks.nvim/blob/main/docs/quickfile.md) | When doing `nvim somefile.txt`, it will render the file as quickly as possible, before loading your plugins. | ‼️ |
-| [rename](https://github.com/folke/snacks.nvim/blob/main/docs/rename.md) | LSP-integrated file renaming with support for plugins like [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) and [mini.files](https://github.com/echasnovski/mini.files). |  |
+| [rename](https://github.com/folke/snacks.nvim/blob/main/docs/rename.md) | LSP-integrated file renaming with support for plugins like [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) and [mini.files](https://github.com/nvim-mini/mini.files). |  |
 | [scope](https://github.com/folke/snacks.nvim/blob/main/docs/scope.md) | Scope detection, text objects and jumping based on treesitter or indent | ‼️ |
 | [scratch](https://github.com/folke/snacks.nvim/blob/main/docs/scratch.md) | Scratch buffers with a persistent file |  |
 | [scroll](https://github.com/folke/snacks.nvim/blob/main/docs/scroll.md) | Smooth scrolling | ‼️ |
@@ -45,7 +45,7 @@ A collection of small QoL plugins for Neovim.
 
 - **Neovim** >= 0.9.4
 - for proper icons support:
-  - [mini.icons](https://github.com/echasnovski/mini.icons) _(optional)_
+  - [mini.icons](https://github.com/nvim-mini/mini.icons) _(optional)_
   - [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) _(optional)_
   - a [Nerd Font](https://www.nerdfonts.com/) **_(optional)_**
 

--- a/doc/snacks-bigfile.txt
+++ b/doc/snacks-bigfile.txt
@@ -13,7 +13,7 @@ Use the `setup` config function to further make changes to a `bigfile` buffer.
 The context provides the actual filetype.
 
 The default implementation enables `syntax` for the buffer and disables
-mini.animate <https://github.com/echasnovski/mini.animate> (if used)
+mini.animate <https://github.com/nvim-mini/mini.animate> (if used)
 
 
 ==============================================================================

--- a/doc/snacks-dashboard.txt
+++ b/doc/snacks-dashboard.txt
@@ -68,13 +68,13 @@ The default preset comes with support for:
 - pickers:
     - fzf-lua <https://github.com/ibhagwan/fzf-lua>
     - telescope.nvim <https://github.com/nvim-telescope/telescope.nvim>
-    - mini.pick <https://github.com/echasnovski/mini.pick>
+    - mini.pick <https://github.com/nvim-mini/mini.pick>
 - session managers: (only works with lazy.nvim <https://github.com/folke/lazy.nvim>)
     - persistence.nvim <https://github.com/folke/persistence.nvim>
     - persisted.nvim <https://github.com/olimorris/persisted.nvim>
     - neovim-session-manager <https://github.com/Shatur/neovim-session-manager>
     - posession.nvim <https://github.com/jedrzejboczar/possession.nvim>
-    - mini.sessions <https://github.com/echasnovski/mini.sessions>
+    - mini.sessions <https://github.com/nvim-mini/mini.sessions>
 
 
 SECTION ACTIONS                       *snacks-dashboard-usage-section-actions*

--- a/doc/snacks-indent.txt
+++ b/doc/snacks-indent.txt
@@ -15,7 +15,7 @@ Visualize indent guides and scopes based on treesitter or indent.
 Similar plugins:
 
 - indent-blankline.nvim <https://github.com/lukas-reineke/indent-blankline.nvim>
-- mini.indentscope <https://github.com/echasnovski/mini.indentscope>
+- mini.indentscope <https://github.com/nvim-mini/mini.indentscope>
 
 
 ==============================================================================

--- a/doc/snacks-picker.txt
+++ b/doc/snacks-picker.txt
@@ -203,7 +203,7 @@ Some acknowledgements:
 
 - fzf-lua <https://github.com/ibhagwan/fzf-lua>
 - telescope.nvim <https://github.com/nvim-telescope/telescope.nvim>
-- mini.pick <https://github.com/echasnovski/mini.pick>
+- mini.pick <https://github.com/nvim-mini/mini.pick>
 
 
 ==============================================================================

--- a/doc/snacks-rename.txt
+++ b/doc/snacks-rename.txt
@@ -13,7 +13,7 @@ Table of Contents                            *snacks-rename-table-of-contents*
   - Snacks.rename.rename_file()|snacks-rename-module-snacks.rename.rename_file()|
 LSP-integrated file renaming with support for plugins like neo-tree.nvim
 <https://github.com/nvim-neo-tree/neo-tree.nvim> and mini.files
-<https://github.com/echasnovski/mini.files>.
+<https://github.com/nvim-mini/mini.files>.
 
 
 ==============================================================================

--- a/doc/snacks-scope.txt
+++ b/doc/snacks-scope.txt
@@ -14,7 +14,7 @@ Table of Contents                             *snacks-scope-table-of-contents*
 Scope detection based on treesitter or indent.
 
 The indent-based algorithm is similar to what is used in mini.indentscope
-<https://github.com/echasnovski/mini.indentscope>.
+<https://github.com/nvim-mini/mini.indentscope>.
 
 
 ==============================================================================

--- a/doc/snacks-scroll.txt
+++ b/doc/snacks-scroll.txt
@@ -13,7 +13,7 @@ Smooth scrolling for Neovim. Properly handles `scrolloff` and mouse scrolling.
 
 Similar plugins:
 
-- mini.animate <https://github.com/echasnovski/mini.animate>
+- mini.animate <https://github.com/nvim-mini/mini.animate>
 - neoscroll.nvim <https://github.com/karb94/neoscroll.nvim>
 
 

--- a/doc/snacks.nvim.txt
+++ b/doc/snacks.nvim.txt
@@ -109,7 +109,7 @@ REQUIREMENTS                            *snacks.nvim-snacks.nvim-requirements*
 
 - **Neovim** >= 0.9.4
 - for proper icons support:
-    - mini.icons <https://github.com/echasnovski/mini.icons> _(optional)_
+    - mini.icons <https://github.com/nvim-mini/mini.icons> _(optional)_
     - nvim-web-devicons <https://github.com/nvim-tree/nvim-web-devicons> _(optional)_
     - a Nerd Font <https://www.nerdfonts.com/> **(optional)**
 

--- a/docs/bigfile.md
+++ b/docs/bigfile.md
@@ -8,7 +8,7 @@ Use the `setup` config function to further make changes to a `bigfile` buffer.
 The context provides the actual filetype.
 
 The default implementation enables `syntax` for the buffer and disables
-[mini.animate](https://github.com/echasnovski/mini.animate) (if used)
+[mini.animate](https://github.com/nvim-mini/mini.animate) (if used)
 
 <!-- docgen -->
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -26,13 +26,13 @@ The default preset comes with support for:
 - pickers:
   - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
   - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
-  - [mini.pick](https://github.com/echasnovski/mini.pick)
+  - [mini.pick](https://github.com/nvim-mini/mini.pick)
 - session managers: (only works with [lazy.nvim](https://github.com/folke/lazy.nvim))
   - [persistence.nvim](https://github.com/folke/persistence.nvim)
   - [persisted.nvim](https://github.com/olimorris/persisted.nvim)
   - [neovim-session-manager](https://github.com/Shatur/neovim-session-manager)
   - [posession.nvim](https://github.com/jedrzejboczar/possession.nvim)
-  - [mini.sessions](https://github.com/echasnovski/mini.sessions)
+  - [mini.sessions](https://github.com/nvim-mini/mini.sessions)
 
 ### Section actions
 

--- a/docs/indent.md
+++ b/docs/indent.md
@@ -5,7 +5,7 @@ Visualize indent guides and scopes based on treesitter or indent.
 Similar plugins:
 
 - [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim)
-- [mini.indentscope](https://github.com/echasnovski/mini.indentscope)
+- [mini.indentscope](https://github.com/nvim-mini/mini.indentscope)
 
 ![image](https://github.com/user-attachments/assets/56a99495-05ab-488e-9619-574cb7ff2b7d)
 

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -28,7 +28,7 @@ Some acknowledgements:
 
 - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
-- [mini.pick](https://github.com/echasnovski/mini.pick)
+- [mini.pick](https://github.com/nvim-mini/mini.pick)
 
 ## 📚 Usage
 

--- a/docs/rename.md
+++ b/docs/rename.md
@@ -1,11 +1,11 @@
 # 🍿 rename
 
 LSP-integrated file renaming with support for plugins like
-[neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) and [mini.files](https://github.com/echasnovski/mini.files).
+[neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) and [mini.files](https://github.com/nvim-mini/mini.files).
 
 ## 🚀 Usage
 
-## [mini.files](https://github.com/echasnovski/mini.files)
+## [mini.files](https://github.com/nvim-mini/mini.files)
 
 ```lua
 vim.api.nvim_create_autocmd("User", {

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -3,7 +3,7 @@
 Scope detection based on treesitter or indent.
 
 The indent-based algorithm is similar to what is used
-in [mini.indentscope](https://github.com/echasnovski/mini.indentscope).
+in [mini.indentscope](https://github.com/nvim-mini/mini.indentscope).
 
 <!-- docgen -->
 

--- a/docs/scroll.md
+++ b/docs/scroll.md
@@ -5,7 +5,7 @@ Properly handles `scrolloff` and mouse scrolling.
 
 Similar plugins:
 
-- [mini.animate](https://github.com/echasnovski/mini.animate)
+- [mini.animate](https://github.com/nvim-mini/mini.animate)
 - [neoscroll.nvim](https://github.com/karb94/neoscroll.nvim)
 
 <!-- docgen -->

--- a/lua/snacks/rename.lua
+++ b/lua/snacks/rename.lua
@@ -2,7 +2,7 @@
 local M = {}
 
 M.meta = {
-  desc = "LSP-integrated file renaming with support for plugins like [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) and [mini.files](https://github.com/echasnovski/mini.files).",
+  desc = "LSP-integrated file renaming with support for plugins like [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) and [mini.files](https://github.com/nvim-mini/mini.files).",
 }
 
 -- Renames the provided file, or the current buffer's file.


### PR DESCRIPTION
## Description

All plugins related to the mini.nvim project has been relocated to a GitHub organization, as announced here:

https://github.com/nvim-mini/mini.nvim/discussions/1970

This commit updates all related URL:s in the documentation to refer to the repositories for each plugin at the new organization.

## Related Issue(s)

N/A

## Screenshots

N/A

