### PR TITLE
[grok] fix(explorer/watch): handle nil filename in fs_event callback

### DIFF
--- a/lua/snacks/explorer/watch.lua
+++ b/lua/snacks/explorer/watch.lua
@@ -16,6 +16,14 @@ function M.start(path, cb)
   end
   local handle = assert(vim.uv.new_fs_event())
   local ok, err = handle:start(path, {}, function(_, file, events)
+    -- Handle nil filename (FreeBSD kqueue bug where filename may be unavailable)
+    if file == nil then
+      if not cb then
+        Tree:refresh(path)
+        M.refresh()
+      end
+      return -- Skip cb to avoid errors; refresh only for default behavior
+    end
     file = path .. "/" .. file
     if cb then
       cb(file, events)


### PR DESCRIPTION
## Description

On FreeBSD (kqueue backend), the filename parameter can be nil due to a kernel
bug in LibUV's fs_event. Add a nil check to refresh the directory and avoid
concatenation errors, preserving watch functionality for LSP diagnostics
(e.g., ZLS in Zig files).


