### PR TITLE
fix(dashboard): fix path filtering for `recent_files` with `cwd` option

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -804,7 +804,9 @@ function M.oldfiles(opts)
       if want then
         done[file] = true
         for _, f in ipairs(filter) do
-          if (file:sub(1, #f.path) == f.path) ~= f.want then
+          local matches = file:sub(1, #f.path) == f.path and
+                          (file:len() == #f.path or file:sub(#f.path + 1, #f.path + 1) == "/")
+          if matches ~= f.want then
             want = false
             break
           end


### PR DESCRIPTION
## Description

Fix incorrect path filtering when using `recent_files` section with `cwd`
option in dashboard.

Previously, when setting cwd to `/foo/bar/baz`, files from directories with
the same prefix like `/foo/bar/bazbaz` were incorrectly included in the recent
 files list. This was due to simple string prefix matching without considering
 directory boundaries.

The fix ensures proper directory boundary checking by verifying that the path
either exactly matches the filter path or is followed by a "/" character.

## Screenshots

```lua
return {
  "snacks.nvim",
  ---@type snacks.Config
  opts = {
    dashboard = {
      enabled = true,
      sections = {
        {
          title = "Recent Files " .. vim.uv.cwd(),
          section = "recent_files",
          cwd = true,
        },
      },
    },
  },
}
```

### before
<img width="659" height="149" alt="CleanShot 2025-09-24 at 00 00 13" src="https://github.com/user-attachments/assets/943ad53f-11c5-49d2-b680-f032ad5fee94" />

### after
<img width="639" height="111" alt="CleanShot 2025-09-24 at 00 01 01" src="https://github.com/user-attachments/assets/0dbde991-5164-4afa-9981-ae6707a8fcc0" />

