### PR TITLE
fix(picker/preview): Make directory preview respect item.cwd

### DIFF
--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -12,7 +12,7 @@ function M.directory(ctx)
   local name = path and vim.fn.fnamemodify(path, ":t")
   ctx.preview:set_title(ctx.item.title or name)
   local ls = {} ---@type {file:string, type:"file"|"directory"}[]
-  for file, t in vim.fs.dir(ctx.item.file) do
+  for file, t in vim.fs.dir(path or ctx.item.file) do
     ls[#ls + 1] = { file = file, type = t }
   end
   ctx.preview:set_lines(vim.split(string.rep("\n", #ls), "\n"))


### PR DESCRIPTION
## Description

Changing the `item.cwd` was not being respected by the previewer for directories.
This uses the full path (already computed before) to create the directory preview.

## Related Issue(s)

Not an issue, but a discussion:
https://github.com/folke/snacks.nvim/discussions/2093

