### PR TITLE
fix(dashboard): only load local sessions with mini.sessions

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -829,8 +829,8 @@ function M.sections.session(item)
     { "persisted.nvim", ":lua require('persisted').load()" },
     { "neovim-session-manager", ":SessionManager load_current_dir_session" },
     { "possession.nvim", ":PossessionLoadCwd" },
-    { "mini.sessions", ":lua require('mini.sessions').read()" },
-    { "mini.nvim", ":lua require('mini.sessions').read()" },
+    { "mini.sessions", ":lua if _G.MiniSessions == nil then require('mini.sessions').setup() end; pcall(MiniSessions.read, MiniSessions.config.file)" },
+    { "mini.nvim", ":lua if _G.MiniSessions == nil then require('mini.sessions').setup() end; pcall(MiniSessions.read, MiniSessions.config.file)" },
   }
   for _, plugin in pairs(plugins) do
     if M.have_plugin(plugin[1]) then


### PR DESCRIPTION
## Description

Changes the loading of mini sessions to only load local sessions.
Before this, using zoxide or project pickers and choosing a directory, which does not have a local session would load the latest global session from mini.sessions, since that is the behaviour of `MiniSessions.read()`.
Now a session if only loaded, if there is a local session in the selected directory.

## Related Issue(s)

I first went to mini.sessions because I thought extra functionality was needed there, but it is possible to implement this with the current functionality. Here is the discussion and source of the new command:
https://github.com/nvim-mini/mini.nvim/issues/1920

