### PR TITLE
fix(indent): do not render ext marks for folded lines

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -270,8 +270,11 @@ function M.on_win(win, buf, top, bottom)
       end
       indent = math.min(indent, parent_indent + state.shiftwidth)
       local extmarks = show_indent and indent > 0 and get_extmarks(indent, state)
-      for _, opts in ipairs(extmarks or {}) do
-        vim.api.nvim_buf_set_extmark(buf, ns, l - 1, 0, opts)
+
+      if vim.fn.foldclosed(l) == -1 then
+        for _, opts in ipairs(extmarks or {}) do
+          vim.api.nvim_buf_set_extmark(buf, ns, l - 1, 0, opts)
+        end
       end
     end
   end)
@@ -328,7 +331,8 @@ function M.render_scope(scope, state)
 
   for l = from, to do
     local i = state.indents[l]
-    if (i and i > indent) or vim.g.snacks_indent_overlap or state.blanks[l] then
+
+    if vim.fn.foldclosed(l) == -1 and ((i and i > indent) or vim.g.snacks_indent_overlap or state.blanks[l]) then
       vim.api.nvim_buf_set_extmark(scope.buf, ns, l - 1, 0, {
         virt_text = { { config.scope.char, hl } },
         virt_text_pos = "overlay",
@@ -375,7 +379,8 @@ function M.render_chunk(scope, state)
 
   for l = from, to do
     local i = state.indents[l] - state.leftcol
-    if l == scope.from then -- top line
+    if vim.fn.foldclosed(l) ~= -1 then
+    elseif l == scope.from then -- top line
       if state.breakindent then
         add(l, char.vertical, true)
       end


### PR DESCRIPTION
## Description

I find indent extremely helpful, but also make heavy use of cold folding, where the existing behavior distracts me. This fixes what I see as a minor bug in the indent snack.

## Related Issue(s)

  - Fixes #2222 

## Screenshots

old behavior:
<img width="472" height="203" alt="Screenshot 2025-09-29 at 8 03 20 PM" src="https://github.com/user-attachments/assets/38f7b391-1496-41d0-8df2-a85c68086bd6" />

new behavior:
<img width="469" height="216" alt="Screenshot 2025-09-29 at 8 05 03 PM" src="https://github.com/user-attachments/assets/d42c1093-f2ab-4e00-abf1-5c909267ffe1" />

