### PR TITLE
fix(picker.recent): prevent fd from ignoring entries from projects.pa…

### DIFF
--- a/lua/snacks/picker/source/recent.lua
+++ b/lua/snacks/picker/source/recent.lua
@@ -62,6 +62,7 @@ M.recent = M.files
 ---@type snacks.picker.finder
 function M.projects(opts, ctx)
   local args = {
+    "-I",
     "-H",
     "-t",
     "f",


### PR DESCRIPTION
## Description

If any of the entries from the patterns setting from the projects source is present in '.gitignore', '.ignore', '.fdignore' or the global ignore file, fd will skip it even if the file/directory exists. With this change, fd will always return entries that exist.

In my case I had '_darcs' added to .ignore because I do not want ripgrep and fd to descend into the version control folders and find things in there, but this also resulted in projects that use darcs as the version control not showing up in the projects list despite having _darcs listed in patterns.