### PR TITLE
fix(notifier): include icon in padding in minimal style

### DIFF
--- a/lua/snacks/notifier.lua
+++ b/lua/snacks/notifier.lua
@@ -581,7 +581,9 @@ function N:render(notif)
 
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
-  local pad = self.opts.padding and (win:add_padding() or 2) or 0
+  -- for the minimal style, we also have to factor in the icon width
+  local icon_width = self.opts.style == "minimal" and vim.api.nvim_strwidth(notif.icon) or 0
+  local pad = (self.opts.padding and (win:add_padding() or 2) or 0) + icon_width
   local width = win:border_text_width()
   for _, line in ipairs(lines) do
     width = math.max(width, vim.fn.strdisplaywidth(line) + pad)


### PR DESCRIPTION
## Description

This prevents the text from running underneath the icon when the text is a single line and the text plus padding is less than max_width.

It does not handle the case where the text is longer than max_width (with or without wrap).

## Related Issue(s)

Fixes #2238 

## Screenshots

Before:

<img width="494" height="106" alt="Screenshot 2025-10-03 at 13 52 39" src="https://github.com/user-attachments/assets/fde31ed5-e2ac-4ad3-8ac3-8f74f84456a7" />


After:

<img width="518" height="111" alt="Screenshot 2025-10-03 at 13 53 33" src="https://github.com/user-attachments/assets/0eb72818-d151-40b9-9a0c-dd4d850abba4" />

