### PR TITLE
fix(scratch): use icon[1] when icon is a table to avoid table.concat error

### DIFF
--- a/lua/snacks/scratch.lua
+++ b/lua/snacks/scratch.lua
@@ -180,7 +180,7 @@ function M.open(opts)
 
     local filekey = {
       opts.filekey.count and tostring(vim.v.count1) or "",
-      opts.icon or "",
+      (type(opts.icon) == "table" and opts.icon[1]) or opts.icon or "",
       opts.name:gsub("|", " "),
       opts.filekey.cwd and svim.fs.normalize(assert(uv.cwd())) or "",
       branch,


### PR DESCRIPTION
## Description

Problem: opts.icon can be a table {icon, icon_hl} but the code inserts opts.icon directly into filekey and later does table.concat(filekey, "|"). That crashes when an element is a table.

Fix: use the first element of opts.icon when opts.icon is a table (fallback to opts.icon or "").

## Related Issue(s)

N/A

## Screenshots

This happens when scratch.opts.icon is a table per documentation
<img width="1453" height="159" alt="image" src="https://github.com/user-attachments/assets/c22cf58e-517d-400d-87d4-d05830df530d" />


