### PR TITLE
feat(explorer): add lualine integration for explorer breadcrumb

### DIFF
--- a/docs/explorer.md
+++ b/docs/explorer.md
@@ -94,3 +94,43 @@ Reveals the given file/buffer or the current buffer in the explorer
 ---@param opts? {file?:string, buf?:number}
 Snacks.explorer.reveal(opts)
 ```
+
+## 🎨 Lualine Integration
+
+The explorer provides a lualine component that displays the current file/directory path in the statusline when the explorer window has focus.
+
+### Setup
+
+Add `"snacks_explorer"` to your lualine configuration:
+
+```lua
+require("lualine").setup({
+  sections = {
+    lualine_c = {
+      "filename",
+      "snacks_explorer",
+    },
+  },
+})
+```
+
+### Options
+
+Configure the path display format:
+
+```lua
+{ "snacks_explorer", path_type = "relative" }  -- relative to cwd (default)
+{ "snacks_explorer", path_type = "display" }   -- ~-relative path
+{ "snacks_explorer", path_type = "filename" }  -- just filename
+```
+
+### LazyVim Example
+
+```lua
+{
+  "nvim-lualine/lualine.nvim",
+  opts = function(_, opts)
+    table.insert(opts.sections.lualine_c, { "snacks_explorer", path_type = "relative" })
+  end,
+}
+```

--- a/lua/lualine/components/snacks_explorer.lua
+++ b/lua/lualine/components/snacks_explorer.lua
@@ -1,0 +1,65 @@
+-- Lualine component for snacks.nvim explorer breadcrumb
+--
+-- Shows the current file/directory path when the explorer window has focus
+--
+-- ## Usage
+--
+-- Add "snacks_explorer" component to your lualine configuration:
+--
+--   require("lualine").setup({
+--     sections = {
+--       lualine_c = { "snacks_explorer" },
+--     },
+--   })
+--
+-- ## Options
+--
+-- - `path_type`: Which path to display (default: "relative")
+--   - "relative": Path relative to explorer cwd
+--   - "display": `~`-relative path
+--   - "filename": Just the filename
+--
+--   { "snacks_explorer", path_type = "display" }
+--
+-- The component will automatically:
+-- - Show the current file/directory path with an icon (󰈔 for files, 󰉋 for directories)
+-- - Only appear when the explorer window has focus
+-- - Update as you navigate through the explorer
+
+local M = require("lualine.component"):extend()
+
+function M:init(options)
+  M.super.init(self, options)
+  self.options = vim.tbl_extend("force", {
+    path_type = "relative",
+  }, options or {})
+end
+
+function M:update_status()
+  if not _G.Snacks or not _G.Snacks.explorer or not _G.Snacks.explorer.current_path then
+    return ""
+  end
+
+  local current_win = vim.api.nvim_get_current_win()
+  local explorer_win = _G.Snacks.explorer.list_win
+
+  if not explorer_win or not vim.api.nvim_win_is_valid(explorer_win) or current_win ~= explorer_win then
+    return ""
+  end
+
+  local path_info = _G.Snacks.explorer.current_path
+  local icon = path_info.is_dir and "󰉋 " or "󰈔 "
+  
+  local path
+  if self.options.path_type == "display" then
+    path = path_info.display_path
+  elseif self.options.path_type == "filename" then
+    path = path_info.filename
+  else
+    path = path_info.relative_path
+  end
+  
+  return icon .. " " .. path
+end
+
+return M

--- a/lua/snacks/explorer/actions.lua
+++ b/lua/snacks/explorer/actions.lua
@@ -306,4 +306,66 @@ M.actions.explorer_warn_prev = { action = "explorer_diagnostic", severity = vim.
 M.actions.explorer_error_next = { action = "explorer_diagnostic", severity = vim.diagnostic.severity.ERROR }
 M.actions.explorer_error_prev = { action = "explorer_diagnostic", severity = vim.diagnostic.severity.ERROR, up = true }
 
+function M.update_explorer_path(picker, item)
+  if picker.opts.source ~= "explorer" then
+    _G.Snacks = _G.Snacks or {}
+    _G.Snacks.explorer = _G.Snacks.explorer or {}
+    _G.Snacks.explorer.current_path = nil
+    _G.Snacks.explorer.list_win = nil
+    return
+  end
+
+  if not item or not item.file then
+    _G.Snacks = _G.Snacks or {}
+    _G.Snacks.explorer = _G.Snacks.explorer or {}
+    _G.Snacks.explorer.current_path = nil
+    vim.schedule(function()
+      local ok, lualine = pcall(require, "lualine")
+      if ok and lualine.refresh then
+        lualine.refresh()
+      end
+    end)
+    return
+  end
+
+  _G.Snacks = _G.Snacks or {}
+  _G.Snacks.explorer = _G.Snacks.explorer or {}
+  _G.Snacks.explorer.list_win = picker.list.win.win
+  
+  local cwd = picker:cwd()
+  local relative_path = item.file
+  if vim.startswith(item.file, cwd) then
+    relative_path = item.file:sub(#cwd + 2)
+  end
+  
+  _G.Snacks.explorer.current_path = {
+    full_path = item.file,
+    display_path = vim.fn.fnamemodify(item.file, ":~"),
+    relative_path = relative_path,
+    filename = vim.fn.fnamemodify(item.file, ":t"),
+    dirname = vim.fn.fnamemodify(item.file, ":h:t"),
+    is_dir = item.dir or false,
+  }
+
+  vim.schedule(function()
+    local ok, lualine = pcall(require, "lualine")
+    if ok and lualine.refresh then
+      lualine.refresh()
+    end
+  end)
+end
+
+function M.clear_explorer_state()
+  if _G.Snacks and _G.Snacks.explorer then
+    _G.Snacks.explorer.current_path = nil
+    _G.Snacks.explorer.list_win = nil
+    vim.schedule(function()
+      local ok, lualine = pcall(require, "lualine")
+      if ok and lualine.refresh then
+        lualine.refresh()
+      end
+    end)
+  end
+end
+
 return M

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -108,6 +108,12 @@ M.explorer = {
       },
     },
   },
+  on_change = function(picker, item)
+    require("snacks.explorer.actions").update_explorer_path(picker, item)
+  end,
+  on_close = function()
+    require("snacks.explorer.actions").clear_explorer_state()
+  end,
 }
 
 M.cliphist = {


### PR DESCRIPTION
## Summary

Adds a lualine component that displays breadcrumb/path information for the snacks.nvim explorer in the statusline.

## Features

- New `snacks_explorer` lualine component at `lua/lualine/components/snacks_explorer.lua`
- Configurable path display formats:
  - `relative` - path relative to explorer cwd (default)
  - `display` - `~`-relative path
  - `filename` - just the filename
- Shows file/directory icons (󰈔 for files, 󰉋 for directories)
- Only displays when explorer window has focus
- Auto-updates as you navigate through the explorer

## Implementation

- Added state tracking in `lua/snacks/explorer/actions.lua` with `update_explorer_path()` and `clear_explorer_state()` functions
- Hooked into explorer via `on_change` and `on_close` callbacks in `lua/snacks/picker/config/sources.lua`
- Component integrates with lualine's component discovery system (similar to aerial.nvim)
- Includes documentation in `docs/explorer.md` with setup examples

## Usage

\`\`\`lua
{
  "nvim-lualine/lualine.nvim",
  opts = function(_, opts)
    table.insert(opts.sections.lualine_c, { "snacks_explorer", path_type = "relative" })
  end,
}
\`\`\`