### PR TITLE
feat(toggle): allow notification customization via function

### DIFF
--- a/lua/snacks/toggle.lua
+++ b/lua/snacks/toggle.lua
@@ -16,7 +16,7 @@ M.meta = {
 ---@field wk_desc? string|{ enabled: string, disabled: string }
 ---@field map? fun(mode: string|string[], lhs: string, rhs: string|fun(), opts?: vim.keymap.set.Opts)
 ---@field which_key? boolean
----@field notify? boolean
+---@field notify? boolean|fun(state:boolean, opts: snacks.toggle.Opts)
 local defaults = {
   map = vim.keymap.set, -- keymap.set function to use
   which_key = true, -- integrate with which-key to show enabled/disabled icons and colors
@@ -97,12 +97,17 @@ end
 function Toggle:toggle()
   local state = not self:get()
   self:set(state)
-  if self.opts.notify then
-    Snacks.notify(
-      (state and "Enabled" or "Disabled") .. " **" .. self.opts.name .. "**",
-      { title = self.opts.name, level = state and vim.log.levels.INFO or vim.log.levels.WARN }
-    )
+  if not self.opts.notify then
+    return
   end
+  if type(self.opts.notify) == "function" then
+    self.opts.notify(state, self.opts)
+    return
+  end
+  Snacks.notify(
+    (state and "Enabled" or "Disabled") .. " **" .. self.opts.name .. "**",
+    { title = self.opts.name, level = state and vim.log.levels.INFO or vim.log.levels.WARN }
+  )
 end
 
 ---@param keys string


### PR DESCRIPTION
This is a very small change that make it possible to configure the notification for toggles.

For example, we can display icons instead of the default 'Enabled' / 'Disabled' text, or not use bold.

<img width="454" height="242" alt="image" src="https://github.com/user-attachments/assets/56f2f4c9-ef04-42df-b498-205416103a7a" />

<img width="454" height="242" alt="image" src="https://github.com/user-attachments/assets/a0b1fb6f-4d34-47aa-b790-a18fc790e1c3" />
