### PR TITLE
fix(rename): handle trailing path separators when renaming directories

### DIFF
--- a/lua/snacks/rename.lua
+++ b/lua/snacks/rename.lua
@@ -28,23 +28,29 @@ function M.rename_file(opts)
     return rename()
   end
 
-  local root = vim.fn.getcwd()
+  -- When 'from' is a directory, fnamemodify(..., ":p") adds a trailing slash.
+  -- This causes fnamemodify(..., ":h") to incorrectly calculate the parent.
+  -- Normalize the path by removing any trailing slashes before calculation.
+  local from_for_calc = from:gsub("[/\\]$", "")
 
+  local parent = vim.fn.fnamemodify(from_for_calc, ":h")
+  local name = vim.fn.fnamemodify(from_for_calc, ":t")
+
+  local root = vim.fn.getcwd()
   if from:find(root, 1, true) ~= 1 then
     root = vim.fn.fnamemodify(from, ":p:h")
   end
-
   local extra = from:sub(#root + 2)
 
   vim.ui.input({
-    prompt = "New File Name: ",
-    default = extra,
+    prompt = "New Name: ",
+    default = name,
     completion = "file",
   }, function(value)
-    if not value or value == "" or value == extra then
+    if not value or value == "" or value == name then
       return
     end
-    to = svim.fs.normalize(root .. "/" .. value)
+    to = vim.fs.normalize(parent .. "/" .. value)
     rename()
   end)
 end


### PR DESCRIPTION
Renaming a directory would fail because the parent path was being calculated incorrectly.

## Description

The `vim.fn.fnamemodify(..., ":p")` function appends a trailing separator to directory paths. The subsequent call to `fnamemodify(..., ":h")` would only strip this separator, returning the original directory path instead of its true parent. This caused the rename operation to attempt to move a directory inside itself.

This commit resolves the issue by normalizing the path to remove any trailing slash or backslash *before* extracting its parent and name components. This makes the rename logic robust for both files and directories on all operating systems.
