### PR TITLE
fix(lazygit): check if default config file exists before adding to LG_CONFIG_FILE

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -87,9 +87,12 @@ local function env(opts)
         return v:match("%S")
       end, vim.split(vim.env.LG_CONFIG_FILE or "", ",", { plain = true }))
 
-      -- add the default config file if it's not already there
+      -- add the default config file if it exists and is not already there
       if #config_files == 0 then
-        config_files[1] = svim.fs.normalize(config_dir .. "/config.yml")
+        local default_config = svim.fs.normalize(config_dir .. "/config.yml")
+        if vim.loop.fs_stat(default_config) then
+          config_files[1] = default_config
+        end
       end
 
       -- add the theme file if it's not already there


### PR DESCRIPTION
## Description

I noticed that lazygit was erroring out on open when the default config file was missing even though lazygit outside of neovim opened fine without it. Tracked it to the `LG_CONFIG_FILE` var that tells lazygit to error out when any of the files are missing - and snacks was setting this to include the default config even when it didn't exist. 

## Related Issue(s)

fixes issue: https://github.com/folke/snacks.nvim/issues/1548
