### PR TITLE
fix(projects): normalize item.text for correct Windows support

### DIFF
--- a/lua/snacks/picker/source/recent.lua
+++ b/lua/snacks/picker/source/recent.lua
@@ -110,7 +110,7 @@ function M.projects(opts, ctx)
 
     ---@async
     proc(function(item)
-      local path = item.text
+      local path = svim.fs.normalize(item.text)
       path = path:sub(-1) == "/" and path:sub(1, -2) or path
       path = vim.fs.dirname(path)
       if ctx.filter:match({ file = path, text = path }) then


### PR DESCRIPTION
## Description
`Snacks.picker.projects` would not show correctly projects on Windows. `item.text` was something like `C:\Users\my_user\AppData\Local\nvim-data\lazy\LazyVim\.git\`. 

By normalizing `item.text` it shows correctly the projects.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
None
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

