### PR TITLE
fix(gitbrowse): respect user-specified line_start and line_end fields

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -181,8 +181,8 @@ function M._open(opts)
     if line_start > line_end then
       line_start, line_end = line_end, line_start
     end
-    fields.line_start = line_start
-    fields.line_end = line_end
+    fields.line_start = fields.line_start or line_start
+    fields.line_end = fields.line_end or line_end
   else
     fields.line_start = fields.line_start or vim.fn.line(".")
     fields.line_end = fields.line_end or fields.line_start


### PR DESCRIPTION
When opening a file in the browser, if there is a  user-specified line_start and/or line_end fields, use them in visual mode instead of calculating them.

## Description

The line_start and line_end options are not respected in visual mode when generating links via gitbrowse. This is a problem for code hosting sites such as Azure Dev Ops which use line_start inclusively, but line_end exclusively, causing the highlighted portion in the generated link to not match what was selected in neovim

## Related Issue(s)

  - Fixes #2285