### PR TITLE
fix(dashboard): replace deprecated AutoSession command

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -835,7 +835,7 @@ function M.sections.session(item)
     { "possession.nvim", ":PossessionLoadCwd" },
     { "mini.sessions", ":lua require('mini.sessions').read()" },
     { "mini.nvim", ":lua require('mini.sessions').read()" },
-    { "auto-session", ":SessionRestore" },
+    { "auto-session", ":AutoSession restore" },
   }
   for _, plugin in pairs(plugins) do
     if M.have_plugin(plugin[1]) then


### PR DESCRIPTION
## Description

The command `SessionRestore` from the auto-session plugin is deprecated. Replaced it with `AutoSession restore`.

