### PR TITLE
fix(gitbrowse): send commit as a opt when calling gitbrowse

### DIFF
--- a/doc/snacks-gitbrowse.txt
+++ b/doc/snacks-gitbrowse.txt
@@ -51,6 +51,7 @@ Open the repo of the active file in the browser (e.g., GitHub)
       end,
       ---@type "repo" | "branch" | "file" | "commit" | "permalink"
       what = "commit", -- what to open. not all remotes support all types
+      commit = nil, ---@type string?
       branch = nil, ---@type string?
       line_start = nil, ---@type number?
       line_end = nil, ---@type number?
@@ -105,6 +106,7 @@ Open the repo of the active file in the browser (e.g., GitHub)
 
 >lua
     ---@class snacks.gitbrowse.Fields
+    ---@field commit? string
     ---@field branch? string
     ---@field file? string
     ---@field line_start? number

--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -27,6 +27,7 @@ local defaults = {
   end,
   ---@type "repo" | "branch" | "file" | "commit" | "permalink"
   what = "commit", -- what to open. not all remotes support all types
+  commit = nil, ---@type string?
   branch = nil, ---@type string?
   line_start = nil, ---@type number?
   line_end = nil, ---@type number?
@@ -159,16 +160,19 @@ function M._open(opts)
     file = file and system({ "git", "-C", cwd, "ls-files", "--full-name", file }, "Failed to get git file path")[1],
     line_start = opts.line_start,
     line_end = opts.line_end,
+    commit = opts.commit,
   }
 
-  if opts.what == "permalink" then
-    fields.commit = system(
-      { "git", "-C", cwd, "log", "-n", "1", "--pretty=format:%H", "--", file },
-      "Failed to get latest commit of file"
-    )[1]
-  else
-    local word = vim.fn.expand("<cword>")
-    fields.commit = is_valid_commit_hash(word, cwd) and word or nil
+  if not fields.commit then
+    if opts.what == "permalink" then
+      fields.commit = system(
+        { "git", "-C", cwd, "log", "-n", "1", "--pretty=format:%H", "--", file },
+        "Failed to get latest commit of file"
+      )[1]
+    else
+      local word = vim.fn.expand("<cword>")
+      fields.commit = is_valid_commit_hash(word, cwd) and word or nil
+    end
   end
 
   -- Get visual selection range if in visual mode


### PR DESCRIPTION
## Description

- I was trying to go to the commit page from fugitive commit buffers
- but snacks.nvim doesn't support this (fugitive does) and so I wanted a way to send the commit IDs to the gitbrowse function after parsing it myself in my dotfiles

### changes
- added `commit` option to `gitbrowse` config to allow passing commit hashes directly instead of only auto-detecting from cursor word or file history
- only falls back to auto-detection when `commit` is not explicitly provided

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

