### PR TITLE
fix(picker.qflist): error with qflist picker when the list contains invalid items

### DIFF
--- a/lua/snacks/picker/source/qf.lua
+++ b/lua/snacks/picker/source/qf.lua
@@ -53,15 +53,15 @@ function M.qf(opts, ctx)
         pos = { row, col },
         end_pos = item.end_lnum ~= 0 and { end_row, end_col } or nil,
         text = file .. " " .. text,
-        line = item.text,
+        line = text,
         file = file,
         severity = severities[item.type] or 0,
         buf = item.bufnr,
         item = item,
       }
-    elseif #ret > 0 and ret[#ret].item.text and item.text then
-      ret[#ret].item.text = ret[#ret].item.text .. "\n" .. item.text
-      ret[#ret].item.line = ret[#ret].item.line .. "\n" .. item.text
+    elseif #ret > 0 and ret[#ret].text and item.text then
+      ret[#ret].text = ret[#ret].text .. "\n" .. item.text
+      ret[#ret].line = ret[#ret].line .. "\n" .. item.text
     end
   end
   return ctx.filter:filter(ret)


### PR DESCRIPTION
## Description

There is an issue with the quick fix list picker
This happens when list contains some incomplete or invalid items.
The fallback mechanism in the picker have 2 typos that trigger an error trap 

* The item line number field is item.lnum and not item.line
* A check is done on item.text twice in the same if condition, it should to item.text and item.lnum

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

