### PR TITLE
fix(image): correct render fallback to handle "editor" relative position

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -382,7 +382,11 @@ function M:render_fallback(state)
     self:debug("render_fallback", win)
     local border = setmetatable({ opts = vim.api.nvim_win_get_config(win) }, { __index = Snacks.win }):border_size()
     local pos = vim.api.nvim_win_get_position(win)
-    if (vim.o.showtabline == 2) or (vim.o.showtabline == 1 and vim.fn.tabpagenr("$") > 1) or (Snacks.config.styles.snacks_image.relative ~= "editor") then
+    if
+      (vim.o.showtabline == 2)
+      or (vim.o.showtabline == 1 and vim.fn.tabpagenr("$") > 1)
+      or (Snacks.config.styles.snacks_image.relative ~= "editor")
+    then
       terminal.set_cursor({ pos[1] + border.top, pos[2] + border.left })
     else
       terminal.set_cursor({ pos[1] + 1 + border.top, pos[2] + border.left })


### PR DESCRIPTION
In PR 1560, @phanen reported an additional case that was not handled by that fix when the style is set to `relative = "editor"`. This new patch adds a check to handle that case.

## Description ##

This patch adds a check for `Snacks.config.styles.snacks_image.relative ~= "editor"` to the conditional in render_fallback that handles the off-by-one error. The previous patch fixed the relative = "cursor" case, but introduced a regression in the relative = "editor" case.


