### PR TITLE
fix(image): ENOENT on preview

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -63,7 +63,9 @@ local commands = {
       return M.is_uri(src) and convert:tmpfile("data") or src
     end,
     on_error = function(step)
-      vim.fs.rm(step.file)
+      if uv.fs_stat(step.file) then
+        vim.fs.rm(step.file)
+      end
     end,
   },
   typ = {


### PR DESCRIPTION
After cb6bf052, occationally I get this error when attach snacks.image in fzf-lua previewer

vim.schedule callback: runtime/lua/vim/fs.lua:737:
ENOENT: no such file or directory: /home/phan/.cache/nvim/snacks/image/56bd7d4f-img.shields.io-badge-Made-with-Lua-blueviolet.svg.data
stack traceback:
    [C]: in function 'error'
    runtime/lua/vim/fs.lua:737: in function 'rm'
    snacks.nvim/lua/snacks/image/convert.lua:66: in function 'on_error'
    snacks.nvim/lua/snacks/image/convert.lua:340: in function 'on_step'
    snacks.nvim/lua/snacks/image/convert.lua:434: in function <snacks.nvim/lua/snacks/image/convert.lua:433>
