### PR TITLE
fix(picker): get rid of side effects when previewing tag locations

### DIFF
--- a/lua/snacks/picker/core/preview.lua
+++ b/lua/snacks/picker/core/preview.lua
@@ -353,8 +353,15 @@ function M:loc()
     end
   elseif self.item.search then
     vim.api.nvim_win_call(self.win.win, function()
-      vim.cmd("keepjumps norm! gg")
-      if pcall(vim.cmd, self.item.search) then
+      local found = false
+      vim.fn.cursor(1, 1)
+      if self.item.search:match("^[/?]") then
+        local opts = "cw" .. (self.item.search:sub(1, 1) == "?" and "b" or "")
+        found = vim.fn.search("\\M\\C" .. self.item.search:sub(2), opts) ~= 0
+      else
+        found = pcall(vim.cmd, self.item.search)
+      end
+      if found then
         vim.cmd("norm! zz")
         self:wo({ cursorline = true })
       end


### PR DESCRIPTION
## Description

The current implementation of preview for helptags (and other sources which produce results with tag locations, for that matter) in snacks.picker creates unwanted side effects when browsing the search results, mainly, polluting the search history. This fix changes tag preview code to use the built-in `search()` function for finding the location in the file instead of executing the `/{pattern}` command with `vim.cmd`, which affects neither the search history, nor the jumplist. This is made a special case for tags whose locations begin with `/` or `?`, as outlined in `:help tag-search`. I also add two modifiers to the pattern: `\M` to make sure that it is executed with `'magic'` disabled (again, as described in `:help tag-search`), and `\C` to make the pattern case-insensitive (important so that different locations are previewed for `-l` and `-L`).