### PR TITLE
fix(picker.actions): ensure the current window is updated after tabdrop

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -89,6 +89,7 @@ function M.jump(picker, _, action)
       drop[#drop + 1] = vim.fn.fnameescape(path)
     end
     vim.cmd(cmd .. " " .. table.concat(drop, " "))
+    win = vim.api.nvim_get_current_win()
   else
     for i, item in ipairs(items) do
       -- load the buffer


### PR DESCRIPTION
## Description

Update the winid (in the `win` variable) after `tab drop`.

## Related Issue(s)

Without this patch, when the user set `confirm` to `{ action = "confirm", cmd = "tabdrop" }` and jump to a location in a different tab, since the `win` is still pointing to the original window (tab), there'd be a `Cursor position outside buffer` error.