### PR TITLE
feat(win): add default *Snacks* prefixed `WinSeparator`

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -209,6 +209,7 @@ Snacks.util.set_hl({
   WinKey = "Keyword",
   WinKeySep = "NonText",
   WinKeyDesc = "Function",
+  WinSeparator = "WinSeparator",
 }, { prefix = "Snacks", default = true })
 
 local id = 0


### PR DESCRIPTION
See #2336 