### PR TITLE
fix(layout): provide parent win width/height when relative to win

### DIFF
--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -251,13 +251,9 @@ function M:update()
     top = (vim.o.showtabline == 2 or (vim.o.showtabline == 1 and #vim.api.nvim_list_tabpages() > 1)) and 1 or 0
   end
 
-  local parent_width = layout.relative == "win"
-    and vim.api.nvim_win_get_width(self.root.opts.win or 0)
-    or vim.o.columns;
-
-  local parent_height = layout.relative == "win"
-    and vim.api.nvim_win_get_height(self.root.opts.win or 0)
-    or vim.o.lines - top - bottom;
+  local parent_width = layout.relative == "win" and vim.api.nvim_win_get_width(self.root.opts.win or 0) or vim.o.columns
+  local parent_height = layout.relative == "win" and vim.api.nvim_win_get_height(self.root.opts.win or 0)
+    or vim.o.lines - top - bottom
 
   self:update_box(layout, {
     col = 0,


### PR DESCRIPTION
## Description

When a win is relative = "win" it should size itself relative to that win's size. Currently this only happens correctly when the picker layout is created. All subsequent updates, such as a toggle_preview action, can potentially trigger calls to a function width/height opt with a max_width and max_height smaller than was previously calculated. This feeds into a recursive series of updates triggered by the WinResized event triggering and updating with a yet smaller max_width or max_height. 

Additionally, because win.o.cols and win.o.lines is used, relative/decimal dimensions would not calculate correctly in splits. Screenshots are from a picker configured as 
```
{
    col = 1,
    height = 0.9,
    width = 0.9,
    position = 'float',
    relative = 'win',
}
```
**before** 
<img width="1348" height="1358" alt="image" src="https://github.com/user-attachments/assets/847b0565-afd0-4ca1-b44c-eb63e335afca" />

**after**
<img width="1354" height="1354" alt="image" src="https://github.com/user-attachments/assets/064f25ae-ed17-42c8-8b34-f32652fab02d" />