### PR TITLE
feat(image): close hover win on movement if it was opened manually

### DIFF
--- a/lua/snacks/image/doc.lua
+++ b/lua/snacks/image/doc.lua
@@ -370,6 +370,8 @@ function M.hover()
   local current_win = vim.api.nvim_get_current_win()
   local current_buf = vim.api.nvim_get_current_buf()
 
+  local float = Snacks.image.config.doc.float
+
   if hover and hover.win.win == current_win and hover.win:valid() then
     return
   end
@@ -424,8 +426,14 @@ function M.hover()
         if not hover then
           return true
         end
-        M.hover()
-        if not hover then
+
+        if float then
+          M.hover()
+          if not hover then
+            return true
+          end
+        else
+          M.hover_close()
           return true
         end
       end,


### PR DESCRIPTION
## Description

For images, I prefer to disable both the `inline` and `float` options. This allows me to use `Snacks.image.hover()` to display the image only when needed. While this works, the hover window does not always close when I move the cursor, it only closes when the cursor moves far from the image. 

I believe most users expect the hover window to close whenever the cursor moves, similar to other hover windows like diagnostics or K. Let me know if you disagree. This PR aims to address this issue and will only affect users who have disabled both the `float` and `inline` options, as they will be using `Snacks.image.hover()` manually to open the hover window.

Thanks for this amazing plugin!

## Screenshots

Before:

![before](https://github.com/user-attachments/assets/f796286d-77f7-4384-a2c2-d4f1b26f4c36)

After:

![after](https://github.com/user-attachments/assets/cd892914-86f1-4161-9d92-2c3234417f37)

