### PR TITLE
fix(explorer): differentiate if file or folder when deleting on Windows

### DIFF
--- a/lua/snacks/explorer/actions.lua
+++ b/lua/snacks/explorer/actions.lua
@@ -25,7 +25,9 @@ function M.get_trash_cmds(path)
       "-Command",
       (
         "Add-Type -AssemblyName Microsoft.VisualBasic; "
-        .. "[Microsoft.VisualBasic.FileIO.FileSystem]::DeleteFile('%s','OnlyErrorDialogs', 'SendToRecycleBin')"
+        .. "[Microsoft.VisualBasic.FileIO.FileSystem]::"
+        .. (vim.fn.isdirectory(path) == 0 and "DeleteFile" or "DeleteDirectory")
+        .. "('%s','OnlyErrorDialogs', 'SendToRecycleBin')"
       ):format(path:gsub("\\", "\\\\"):gsub("'", "''")),
     }
   end


### PR DESCRIPTION
## Description
Use different command on Windows for deleting folder/file to avoid error
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #2371
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
