### PR TITLE
feat(picker.explorer): allow sorting when search query is empty

### DIFF
--- a/lua/snacks/picker/source/explorer.lua
+++ b/lua/snacks/picker/source/explorer.lua
@@ -193,7 +193,7 @@ function M.explorer(opts, ctx)
   local state = M.get_state(ctx.picker)
 
   ctx.picker.matcher.opts.keep_parents = false
-  if state:setup(ctx) then
+  if state:setup(ctx) or opts.matcher.sort_empty then
     ctx.picker.matcher.opts.keep_parents = true
     return M.search(opts, ctx)
   end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Allow sorting when search query is empty by using `explorer.search(opts, ctx)` when `opts.matcher.sort_empty` is true, currently I can't sort files if query is empty (sorting by like `item.path` makes tree structure broken)

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
- Fixes #2376

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

