### PR TITLE
fix(picker.git_diff): parsing of filenames and renames

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -256,7 +256,14 @@ end
 ---@type snacks.picker.finder
 function M.diff(opts, ctx)
   opts = opts or {}
-  local args = M.git("diff", "--no-color", "--no-ext-diff", { args = { "--no-pager" } }, opts)
+  local args = M.git(
+    "diff",
+    "--no-color",
+    "--no-ext-diff",
+    "--diff-filter=u",
+    { args = { "-c", "diff.noprefix=false", "--no-pager" } },
+    opts
+  )
   if opts.base then
     vim.list_extend(args, { "--merge-base", opts.base })
   end


### PR DESCRIPTION
## Description

followup to #2366 because current code can't parse `diff --git i/dir a/file w/dir a/file` correctly.
* bring back `diff.noprefix=false` since parsing diff cmd without prefixes is not reliable
* fix renames using old name instead of new name
* add `--diff-filter=u` to filter out `* Unmerged path ...` from output