### PR TITLE
feat(image): improve support of math rendering in norg

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -9,7 +9,7 @@
   `pdf`, `png`, `jpg`, `jpeg`, `gif`, `bmp`, `webp`, `tiff`, `heic`, `avif`, `mp4`, `mov`, `avi`, `mkv`, `webm`
 - Supports inline image rendering in:
   `markdown`, `html`, `norg`, `tsx`, `javascript`, `css`, `vue`, `svelte`, `scss`, `latex`, `typst`
-- LaTex math expressions in `markdown` and `latex` documents
+- LaTex math expressions in `markdown`, `norg`, and `latex` documents
 
 Terminal support:
 

--- a/queries/norg/images.scm
+++ b/queries/norg/images.scm
@@ -3,7 +3,31 @@
   (tag_parameters (tag_param) @image.src)
 ) @image
 
-(inline_math
-  (#set! image.lang "latex")
+(
+  (inline_math
+    (#set! image.lang "latex")
+    (#set! image.ext "math.tex")
+  ) @image.content @image
+  (#lua-match? @image.content "^$|.*|$$") ; remove `|` characters used in rigid math syntax
+  (#gsub! @image.content "^$|" "$")
+  (#gsub! @image.content "|$$" "$")
+)
+
+(
+  (inline_math
+    (#set! image.lang "latex")
+    (#set! image.ext "math.tex")
+  ) @image.content @image
+  ; remove `\` prefix from escape sequences in normal math syntax
+  (#lua-match? @image.content "^$[^|].*$$")
+  (#gsub! @image.content "\\(.)" "%1")
+)
+
+(ranged_verbatim_tag
+  (tag_name) @tagname
+  (#eq? @tagname "math")
+  (tag_parameters)?
+  (ranged_verbatim_tag_content) @image.content
+  (#set! injection.language "latex")
   (#set! image.ext "math.tex")
-) @image.content @image
+) @image

--- a/tests/image/test.norg
+++ b/tests/image/test.norg
@@ -1,31 +1,31 @@
-# Test
+* Test
 
 - foo
 
-This sentence $E = mc^2$ uses delimiters to show math inline: $`\sqrt{3x-1}+(1+x)^2`$
+This sentence $E = mc^2$ uses delimiters to show math inline: $\\sqrt{3x-1}+(1+x)^2$
 
 .image ./test.png
 
 .image test.png
-This sentence uses `$` delimiters to show math inline: $\sqrt{3x-1}+(1+x)^2$
+This sentence uses `$||$` delimiters to show math inline: $|\sqrt{3x-1}+(1+x)^2|$
 
-This sentence $E = mc^2$ uses delimiters to show math inline: $`\sqrt{3x-1}+(1+x)^2`$
+This sentence $E = mc^2$ uses delimiters to show math inline: $\\sqrt{3x-1}+(1+x)^2$
 
-**The Cauchy-Schwarz Inequality**
-$$\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)$$
+*The Cauchy-Schwarz Inequality*
+$|\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)|$
 
-**The Cauchy-Schwarz Inequality**
+*The Cauchy-Schwarz Inequality*
 
-```math
+@math
 \left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
-```
+@end
 
-![image](test copy.png)
+[image]{/ test copy.png}
 
-$\int_0^1 x^2 dx$
+$|\int_0^1 x^2 dx|$
 
-<!-- snacks: header start
+%|`|snacks: header start
 \def\x{5}
-snacks: header end -->
+snacks: header end|`|%
 
-$ \x \leq 17 $
+$| \x \leq 17 |$


### PR DESCRIPTION
## Description

Improves overall support of math rendering in norg files:
- Adds support for display math with `@math` tags
- Properly handle some norg-specific edge-cases in inline math
  - Take escape sequences into account for simple syntax (`$...$`)
  - Remove `|` surrounding delimiters from rigid syntax (`$|...|$`)

Also updates the test file to use correct norg syntax rather than markdown syntax

