### PR TITLE
perf(bigfile): disable completion to avoid lag when entering insert mode

### DIFF
--- a/lua/snacks/bigfile.lua
+++ b/lua/snacks/bigfile.lua
@@ -20,6 +20,7 @@ local defaults = {
       vim.cmd([[NoMatchParen]])
     end
     Snacks.util.wo(0, { foldmethod = "manual", statuscolumn = "", conceallevel = 0 })
+    vim.b.completion = false
     vim.b.minianimate_disable = true
     vim.b.minihipatterns_disable = true
     vim.schedule(function()


### PR DESCRIPTION
## Description

Default LazyVim uses the extra [Blink.cmp](https://github.com/saghen/blink.cmp) which creates lag (multiple seconds in a 600MB `csv` test file) when entering insert mode.