### PR TITLE
fix(picker.spinner): when parent win is not float win

### DIFF
--- a/lua/snacks/picker/util/spinner.lua
+++ b/lua/snacks/picker/util/spinner.lua
@@ -100,7 +100,7 @@ function M.loading(msg, opts)
     focusable = false,
     enter = false,
     relative = "win",
-    zindex = vim.api.nvim_win_get_config(parent_win).zindex + 1,
+    zindex = (vim.api.nvim_win_get_config(parent_win).zindex or 50) + 1,
     width = vim.api.nvim_strwidth(msg) + 1,
     height = 1,
     border = "rounded",


### PR DESCRIPTION
When use checkout PR action from `gh://` buffer

```
vim.schedule callback: snacks.nvim/lua/snacks/picker/util/spinner.lua:103: attempt to perform arithmetic on field 'zindex' (a nil value)
stack traceback:
  snacks.nvim/lua/snacks/picker/util/spinner.lua:103: in function 'loading'
  snacks.nvim/lua/snacks/gh/actions.lua:796: in function '_run'
  snacks.nvim/lua/snacks/gh/actions.lua:791: in function 'fn'
  snacks.nvim/lua/snacks/picker/util/init.lua:90: in function 'on_choice'
  snacks.nvim/lua/snacks/picker/select.lua:59: in function <snacks.nvim/lua/snacks/picker/select.lua:58>
```

