### PR TITLE
fix(picker.actions): `put` action always moving cursor to the EoL

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -610,7 +610,7 @@ function M.paste(picker, item, action)
         if col == eol then
           vim.cmd.startinsert({ bang = true })
         else
-          vim.cmd.normal { "l", bang = true }
+          vim.cmd.normal({ "l", bang = true })
           vim.cmd.startinsert()
         end
       end)


### PR DESCRIPTION
## Description

when used in insert mode, the `put` action, by default used by the `icon` source, always moves the cursor to the end of the line instead of the end of the pasted text.

The issue arises since `:startinsert!` (with bang) behaves like `A`, not like `a`. Since `nvim_paste` moves the cursor onto the last pasted character, we need `a` to correctly position the cursor when re-entering insert mode. However, `:startinsert` behaves like `i` and `:startinsert!` like `A`, so we need to check whether we are at the end of the line to determine whether we emulate `il` or `A` for correct cursor positioning.

Whether we are at the end of the line cannot simply be determined with `nvim_win_get_cursor` and `nvim_get_current_line`, since emojis/nerdfonts affect the string length. Instead of convoluted string width calculations, using `fn.virtcol` is simpler and also does the job.