### PR TITLE
fix(picker.tags): escape magic chars in tag search to avoid jump error

### DIFF
--- a/lua/snacks/picker/source/vim.lua
+++ b/lua/snacks/picker/source/vim.lua
@@ -361,13 +361,25 @@ function M.tags(opts, ctx)
     T = "TypeParameter",
   }
 
+  ---@param str string
+  ---@return string
+  local function escape_magic_characters(str)
+    -- replace * 
+    str = str:gsub("%*", "\\*")
+    -- replace [
+    str = str:gsub("%[", "\\[")
+    -- replace ]
+    str = str:gsub("%]", "\\]")
+    return str
+  end
+
   for _, tag in ipairs(tags) do
     ---@type snacks.picker.finder.Item
     local item = {
       text = tag.name,
       name = tag.name,
       file = tag.filename,
-      search = tag.cmd,
+      search = escape_magic_characters(tag.cmd),
       kind = tag.kind,
       lsp_kind = lsp_kinds[tag.kind] or "Text",
     }


### PR DESCRIPTION
When parsing vim tags, the search command associated with a tag can contain characters that have special meaning in Vim regex (like `*`, `[`, `]`).

This introduces an `escape_magic_characters` helper function to escape these characters in the tag's `cmd` field before assigning it to the item's `search` property. This prevents errors or incorrect matching when jumping to tag definitions that contain these special characters.

For example, searching for the following tag files can resulting in the following error:

```tags
md_files	.builds/gen-readme.py	/^md_files = [re.sub("^.\/", "", i) for i in md_files if i != ""]$/;"	v	language:Python	access:public
```

Searching this tag will get the following error:

```error
Error executing vim.schedule lua callback: vim/_editor.lua:0: nvim_exec2(), line 1: Vim:E486: Pattern not found: ^md_files = [re.sub("^.\/", "", i) for i in md_
files if i != ""]$
```

Another tag:

```tags
Cancellation :cancellation:	Fall2025.org	/^*** Cancellation :cancellation:$/;"	s	language:Org
```

Searching this tag will get the following error:

```error
Error executing vim.schedule lua callback: vim/_editor.lua:0: nvim_exec2(), line 1: Vim:E871: (NFA regexp) Can't have a multi follow a multi
```

