### PR TITLE
docs(docs.lazygit): fix typo in lazygit.md

### DIFF
--- a/docs/lazygit.md
+++ b/docs/lazygit.md
@@ -44,7 +44,7 @@ and integrate edit with the current neovim instance.
       nerdFontsVersion = "3",
     },
   },
-  theme_path = svim.fs.normalize(vim.fn.stdpath("cache") .. "/lazygit-theme.yml"),
+  theme_path = vim.fs.normalize(vim.fn.stdpath("cache") .. "/lazygit-theme.yml"),
   -- Theme for lazygit
   theme = {
     [241]                      = { fg = "Special" },


### PR DESCRIPTION
Fixing typo on the documentation page

https://github.com/folke/snacks.nvim/issues/2562

