### PR TITLE
feat(gh): prompt for repository when not in a git repo

### DIFF
--- a/docs/gh.md
+++ b/docs/gh.md
@@ -20,6 +20,7 @@ A modern GitHub CLI integration for Neovim that brings GitHub issues and pull re
 - 🔗 Open issues/PRs in your web browser
 - 📎 Yank URLs to clipboard
 - 🌲 Built on top of the powerful [Snacks picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
+- 🌐 **Browse any repository** - when not in a git repo, you'll be prompted to enter a repository (e.g., `folke/snacks.nvim`)
 
 ## ⚡️ Requirements
 
@@ -74,12 +75,20 @@ Snacks.picker.gh_pr()
 -- Browse all pull requests
 Snacks.picker.gh_pr({ state = "all" })
 
+-- Browse issues/PRs for a specific repository (works from anywhere)
+Snacks.picker.gh_issue({ repo = "folke/snacks.nvim" })
+Snacks.picker.gh_pr({ repo = "neovim/neovim" })
+
 -- View PR diff
 Snacks.picker.gh_diff({ pr = 123 })
 
 -- Open issue/PR in buffer
 Snacks.gh.open({ type = "issue", number = 123, repo = "owner/repo" })
 ```
+
+> **Note**: When running outside a git repository, you'll be prompted to enter a repository
+> in `owner/repo` format (e.g., `folke/snacks.nvim`). You can also skip the prompt by
+> passing the `repo` option directly.
 
 ### Available Actions
 

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -112,6 +112,7 @@ local M = {}
 ---@field on_close? fun(picker:snacks.Picker) called when the picker is closed
 ---@field jump? snacks.picker.jump.Config|{}
 --- Other
+---@field abort? boolean when set by a config function, the picker will not be opened
 ---@field config? fun(opts:snacks.picker.Config):snacks.picker.Config? custom config function
 ---@field db? snacks.picker.db.Config|{}
 ---@field debug? snacks.picker.debug|{}

--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -77,7 +77,7 @@ end
 
 ---@hide
 ---@param opts? snacks.picker.Config
----@return snacks.Picker
+---@return snacks.Picker?
 function M.new(opts)
   ---@type snacks.Picker
   local self = setmetatable({}, M)
@@ -85,6 +85,11 @@ function M.new(opts)
   self.id = _id
   self.init_opts = opts
   self.opts = Snacks.picker.config.get(opts)
+
+  -- Allow config functions to abort picker creation
+  if self.opts.abort then
+    return nil
+  end
 
   self.history = require("snacks.picker.util.history").new("picker_" .. (self.opts.source or "custom"), {
     ---@param hist snacks.picker.history.Record


### PR DESCRIPTION
Closes: #2565 

When running `Snacks.picker.gh_issue()` or `Snacks.picker.gh_pr()` outside of a git repository, the user is now prompted to enter a repository in `owner/repo` format.

## Changes
- Added `gh_prompt_repo` helper function that prompts for repository input
- Added `abort` config option to allow aborting picker creation
- Updated documentation with new feature and usage examples

## Usage
When not in a git repo:
```lua
Snacks.picker.gh_issue()  -- prompts for repo
Snacks.picker.gh_pr()     -- prompts for repo

-- Or specify directly:
Snacks.picker.gh_issue({ repo = "folke/snacks.nvim" })
```
## Screenshots

While not in a local repo:

<img width="746" height="81" alt="Screenshot 2025-11-27 at 2 43 06 PM" src="https://github.com/user-attachments/assets/3b2671e2-3d69-4821-a172-66b1b4cb2dcc" />

<img width="2037" height="1025" alt="Screenshot 2025-11-27 at 2 43 48 PM" src="https://github.com/user-attachments/assets/1d658acd-0b18-42ec-96ed-3196554aac55" />
