### PR TITLE
feat(zen): add explicit enable and disable methods

### DIFF
--- a/lua/snacks/zen.lua
+++ b/lua/snacks/zen.lua
@@ -101,18 +101,40 @@ end
 
 M.win = nil ---@type snacks.win?
 
+local function enabled()
+  if M.win and M.win:valid() then
+    return true
+  end
+  return false
+end
+
 ---@param opts? snacks.zen.Config
 function M.zen(opts)
+  -- close if already open
+  if M.disable() then
+    return
+  end
+  return M.enable(opts)
+end
+
+function M.disable()
+  if not enabled() then
+    return
+  end
+  M.win:close()
+  M.win = nil
+  return true
+end
+
+---@param opts? snacks.zen.Config
+function M.enable(opts)
+  if enabled() then
+    return
+  end
+
   local toggles = opts and opts.toggles
   opts = Snacks.config.get("zen", defaults, opts)
   opts.toggles = toggles or opts.toggles
-
-  -- close if already open
-  if M.win and M.win:valid() then
-    M.win:close()
-    M.win = nil
-    return
-  end
 
   local parent_win = vim.api.nvim_get_current_win()
   local parent_zindex = vim.api.nvim_win_get_config(parent_win).zindex


### PR DESCRIPTION
## Description

Currently, the zen module only exposes a method to toggle its functionality on and off with the same method (`Snacks.zen(opts)`).

This change adds an explicit `Snacks.zen.enable(opts)` and `Snacks.zen.disable()` method respectively.
The module thereby also more closely mirrors other modules with explicit enable/disable functionality, like 'scroll', 'dim', or 'words'.

The naming of all methods tries to follow the same naming scheme as the other modules:

- `enabled()` (current state, local function)
- `M.enable(opts)` (explicit enable)
- `M.disable()` (explicit disable)

and `M.zen(opts)` retains its original toggle functionality.

## Related Issue(s)

none found

## Screenshots

n/a, no visible changes.
