### PR TITLE
feat(lazygit): set default width and height to 0.9

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -60,7 +60,10 @@ local defaults = {
   },
 }
 
-Snacks.config.style("lazygit", {})
+Snacks.config.style("lazygit", {
+  width = 0.9,
+  height = 0.9,
+})
 
 -- re-create config file on startup
 local dirty = true


### PR DESCRIPTION
When default values are not set, they will be inherited from terminal's width and height, which can break lazygit's UI

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
  When the default window sizes are not set, they will be inherited from terminal's explicitly set `width` and `height`, and that will break the lazygit's UI. The lazygit's `height` and `width` shouldn't depend on the `height` and `width` which are set for terminal in `styles`

## Related Issue(s)
https://github.com/folke/snacks.nvim/issues/2568
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

