### PR TITLE
fix(lazygit): border color using bg instead of fg

### DIFF
--- a/doc/snacks.nvim-lazygit.txt
+++ b/doc/snacks.nvim-lazygit.txt
@@ -62,13 +62,13 @@ colorscheme and integrate edit with the current neovim instance.
       -- Theme for lazygit
       theme = {
         [241]                      = { fg = "Special" },
-        activeBorderColor          = { fg = "MatchParen", bold = true },
+        activeBorderColor          = { bg = "MatchParen", bold = true },
         cherryPickedCommitBgColor  = { fg = "Identifier" },
         cherryPickedCommitFgColor  = { fg = "Function" },
         defaultFgColor             = { fg = "Normal" },
         inactiveBorderColor        = { fg = "FloatBorder" },
         optionsTextColor           = { fg = "Function" },
-        searchingActiveBorderColor = { fg = "MatchParen", bold = true },
+        searchingActiveBorderColor = { bg = "MatchParen", bold = true },
         selectedLineBgColor        = { bg = "Visual" }, -- set to `default` to have no background colour
         unstagedChangesColor       = { fg = "DiagnosticError" },
       },

--- a/docs/lazygit.md
+++ b/docs/lazygit.md
@@ -48,13 +48,13 @@ and integrate edit with the current neovim instance.
   -- Theme for lazygit
   theme = {
     [241]                      = { fg = "Special" },
-    activeBorderColor          = { fg = "MatchParen", bold = true },
+    activeBorderColor          = { bg = "MatchParen", bold = true },
     cherryPickedCommitBgColor  = { fg = "Identifier" },
     cherryPickedCommitFgColor  = { fg = "Function" },
     defaultFgColor             = { fg = "Normal" },
     inactiveBorderColor        = { fg = "FloatBorder" },
     optionsTextColor           = { fg = "Function" },
-    searchingActiveBorderColor = { fg = "MatchParen", bold = true },
+    searchingActiveBorderColor = { bg = "MatchParen", bold = true },
     selectedLineBgColor        = { bg = "Visual" }, -- set to `default` to have no background colour
     unstagedChangesColor       = { fg = "DiagnosticError" },
   },

--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -45,13 +45,13 @@ local defaults = {
   -- stylua: ignore
   theme = {
     [241]                      = { fg = "Special" },
-    activeBorderColor          = { fg = "MatchParen", bold = true },
+    activeBorderColor          = { bg = "MatchParen", bold = true },
     cherryPickedCommitBgColor  = { fg = "Identifier" },
     cherryPickedCommitFgColor  = { fg = "Function" },
     defaultFgColor             = { fg = "Normal" },
     inactiveBorderColor        = { fg = "FloatBorder" },
     optionsTextColor           = { fg = "Function" },
-    searchingActiveBorderColor = { fg = "MatchParen", bold = true },
+    searchingActiveBorderColor = { bg = "MatchParen", bold = true },
     selectedLineBgColor        = { bg = "Visual" }, -- set to `default` to have no background colour
     unstagedChangesColor       = { fg = "DiagnosticError" },
   },


### PR DESCRIPTION
## Description

This issue shows a black fallback color activeborder in tokyonight theme, the color shows correctly after changing to bg in config 

## Related Issue(s)

No issue related

## Screenshots

This is before:

<img width="373" height="445" alt="image" src="https://github.com/user-attachments/assets/2fb9537e-0bc1-40fe-9846-573837d25a61" />
<img width="810" height="230" alt="image" src="https://github.com/user-attachments/assets/3b98f94b-d831-4090-b264-f573326531b5" />

This is after:

<img width="370" height="395" alt="image" src="https://github.com/user-attachments/assets/f74236a7-7b4c-41d9-a016-4fdc7abbe5c9" />
<img width="810" height="230" alt="image" src="https://github.com/user-attachments/assets/91606b75-d9f0-4e86-b544-4b399d208928" />



