### PR TITLE
fix(image): handle long filenames on macOS with hash

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -292,7 +292,13 @@ end
 
 ---@param ft string
 function Convert:tmpfile(ft)
-  return Snacks.image.config.cache .. "/" .. self.prefix .. "." .. ft
+  -- If it is macOS and the file name is too long
+  if jit.os:find("OSX") and #self.opts.src > 254 then
+    local hash = vim.fn.sha256(self.opts.src .. self.page):sub(1, 16)
+    return Snacks.image.config.cache .. "/" .. hash .. "." .. ft
+  else
+    return Snacks.image.config.cache .. "/" .. self.prefix .. "." .. ft
+  end
 end
 
 ---@param target string


### PR DESCRIPTION


## Description

On macOS, file names longer than 255 characters are not supported. This change checks if the source file name exceeds this limit and, if so, uses a hash of the source and page as the cache file name. This prevents errors when dealing with very long file names.
hange checks if the source file name exceeds this limit and, if so, uses a hash of the source and page as the cache file name. This prevents errors when dealing with very long file names.

## Related issue

#2506

## Screenshots

<img width="599" height="677" alt="image" src="https://github.com/user-attachments/assets/0641eb91-7e21-4627-bd5e-58c85c1efd64" />

