### PR TITLE
fix(picker.list): correct row2idx calculation in reverse mode

### DIFF
--- a/lua/snacks/picker/core/list.lua
+++ b/lua/snacks/picker/core/list.lua
@@ -200,7 +200,7 @@ function M:row2idx(row)
   if not self.reverse then
     return ret
   end
-  return self.state.height - ret + 1
+  return self.top + self.state.height - row
 end
 
 function M:on_show()


### PR DESCRIPTION
## Description

This PR addresses an issue where cursor movement and `flash.nvim` integration behave abnormally when using `picker.list` with a reverse layout (e.g., `telescope`).

The issue was caused by a mismatch between the item index (`idx`) and the visual row (`row`) in reverse mode. 
- In function row2idx(list.lua:203): ret = row + self.top - 1 the original return value was: self.state.height - ret + 1 which expands to: self.state.height - (row + self.top - 1) + 1 = self.state.height - row - self.top + 2
- For row in the range 1..self.state.height, ret ranges from self.top to (self.top + self.state.height - 1), so the return value’s minimum is roughly -self.top + 2，which can be less than zero.

This fix ensures that:
- Cursor navigation correctly maps to the intended visual item in reverse lists.
- `flash` jumps target the correct item regardless of the list direction.
## Related Issue(s)

Fixes #2605

## Screenshots

after: 

https://github.com/user-attachments/assets/b15969b8-6bc6-467a-bfd3-91d1124c1682


<!-- Add screenshots of the changes if applicable. -->

