### PR TITLE
feat(gitbrowse): use upstream branch name when available.

### DIFF
--- a/doc/snacks.nvim-gitbrowse.txt
+++ b/doc/snacks.nvim-gitbrowse.txt
@@ -55,6 +55,8 @@ Open the repo of the active file in the browser (e.g., GitHub)
       branch = nil, ---@type string?
       line_start = nil, ---@type number?
       line_end = nil, ---@type number?
+      ---@type boolean
+      only_upstream_remote = false, -- if branch = nil and upstream of the current branch is found, do not consider other remotes
       -- patterns to transform remotes to an actual URL
       remote_patterns = {
         { "^(https?://.*)%.git$"              , "%1" },

--- a/docs/gitbrowse.md
+++ b/docs/gitbrowse.md
@@ -43,6 +43,8 @@ Open the repo of the active file in the browser (e.g., GitHub)
   branch = nil, ---@type string?
   line_start = nil, ---@type number?
   line_end = nil, ---@type number?
+  ---@type boolean
+  only_upstream_remote = false, -- if branch = nil and upstream of the current branch is found, do not consider other remotes
   -- patterns to transform remotes to an actual URL
   remote_patterns = {
     { "^(https?://.*)%.git$"              , "%1" },

--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -31,6 +31,8 @@ local defaults = {
   branch = nil, ---@type string?
   line_start = nil, ---@type number?
   line_end = nil, ---@type number?
+  ---@type boolean
+  only_upstream_remote = false, -- if branch = nil and upstream of the current branch is found, do not consider other remotes
   -- patterns to transform remotes to an actual URL
   -- stylua: ignore
   remote_patterns = {
@@ -236,7 +238,8 @@ function M._open(opts)
 
   for _, line in ipairs(system({ "git", "-C", cwd, "remote", "-v" }, "Failed to get git remotes")) do
     local name, remote = line:match("(%S+)%s+(%S+)%s+%(fetch%)")
-    if name and remote then
+    local skip = opts.only_upstream_remote and opts.branch == nil and upstream ~= nil and name ~= upstream
+    if name and remote and not skip then
       local repo = M.get_repo(remote, opts)
       if repo then
         local old_fields_branch = fields.branch


### PR DESCRIPTION
## Description

When branch is not overridden via options, the local name of the current
branch is transformed into the name of the remote branch that
corresponds to the local branch via (transitive) upstream relation (as
established via git branch --set-upstream-to).

When branch is overridden, its upstream branch name is not looked up, as
we are assuming that a user-specified branch name is in the context of
the remote.

Also added option only_upstream_remote.
Setting this to true limits the remotes list to the single element when
branch is not overridden via options and its upstream remote is found,
effectively bypassing vim.ui.select.

## Related Issue(s)

- Closes #2613 
