### PR TITLE
feat(picker.actions): configurable chars for pick_win

### DIFF
--- a/docs/picker.md
+++ b/docs/picker.md
@@ -111,6 +111,7 @@ Snacks.picker.pick({source = "files", ...})
 ---@field on_show? fun(picker:snacks.Picker) called when the picker is shown
 ---@field on_close? fun(picker:snacks.Picker) called when the picker is closed
 ---@field jump? snacks.picker.jump.Config|{}
+---@field pick_win? snacks.picker.pick_win.Config|{}
 --- Other
 ---@field config? fun(opts:snacks.picker.Config):snacks.picker.Config? custom config function
 ---@field db? snacks.picker.db.Config|{}
@@ -208,6 +209,10 @@ Snacks.picker.pick({source = "files", ...})
     reuse_win = false, -- reuse an existing window if the buffer is already open
     close = true, -- close the picker when jumping/editing to a location (defaults to true)
     match = false, -- jump to the first match position. (useful for `lines`)
+  },
+  ---@class snacks.picker.pick_win.Config
+  pick_win = {
+    selection_chars = "asdfghjkl" -- letters used for picking windows
   },
   toggles = {
     follow = "f",

--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -318,7 +318,7 @@ function M.pick_win(picker, item, action)
   if not picker.layout.split then
     picker.layout:hide()
   end
-  local win = Snacks.picker.util.pick_win({ main = picker.main })
+  local win = Snacks.picker.util.pick_win({ main = picker.main, selection_chars = picker.opts.pick_win.selection_chars })
   if not win then
     if not picker.layout.split then
       picker.layout:unhide()

--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -111,6 +111,7 @@ local M = {}
 ---@field on_show? fun(picker:snacks.Picker) called when the picker is shown
 ---@field on_close? fun(picker:snacks.Picker) called when the picker is closed
 ---@field jump? snacks.picker.jump.Config|{}
+---@field pick_win? snacks.picker.pick_win.Config|{}
 --- Other
 ---@field config? fun(opts:snacks.picker.Config):snacks.picker.Config? custom config function
 ---@field db? snacks.picker.db.Config|{}
@@ -208,6 +209,10 @@ local defaults = {
     reuse_win = false, -- reuse an existing window if the buffer is already open
     close = true, -- close the picker when jumping/editing to a location (defaults to true)
     match = false, -- jump to the first match position. (useful for `lines`)
+  },
+  ---@class snacks.picker.pick_win.Config
+  pick_win = {
+    selection_chars = "asdfghjkl" -- letters used for picking windows
   },
   toggles = {
     follow = "f",

--- a/lua/snacks/picker/util/init.lua
+++ b/lua/snacks/picker/util/init.lua
@@ -443,16 +443,17 @@ function M.shallow_copy(t)
   return setmetatable(ret, getmetatable(t))
 end
 
----@param opts? {main?: number, float?:boolean, filter?: fun(win:number, buf:number):boolean?}
+---@param opts? {main?: number, float?:boolean, selection_chars?: string, filter?: fun(win:number, buf:number):boolean?}
 function M.pick_win(opts)
   opts = Snacks.config.merge({
     filter = function(win, buf)
       return not vim.bo[buf].filetype:find("^snacks")
     end,
+    selection_chars = "asdfghjkl"
   }, opts)
 
   local overlays = {} ---@type snacks.win[]
-  local chars = "asdfghjkl"
+  local chars = opts.selection_chars
   local wins = {} ---@type number[]
   for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
     local buf = vim.api.nvim_win_get_buf(win)


### PR DESCRIPTION
## Description

Previously, the `pick_win` action in `snacks.nvim` used a hardcoded string (`"asdfghjkl"`) to label picking windows. This PR adds the ability to customize the label string, allowing users to specify their preferred characters (e.g., `"fjdksla;cmrueiwoqp"`, as it is by default in [nvim-window-picker](github.com/s1n7ax/nvim-window-picker) plugin). 




