### PR TITLE
fix(dashboard): fix `M.have_plugin` for `mini.nvim` explicitly

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -777,6 +777,9 @@ end
 -- Only works with [lazy.nvim](https://github.com/folke/lazy.nvim)
 ---@param name string
 function M.have_plugin(name)
+  if name:match("^mini%.nvim") then
+    return package.loaded.lazy and require("lazy.core.config").spec.plugins[name] ~= nil and _G.MiniSessions ~= nil
+  end
   return package.loaded.lazy and require("lazy.core.config").spec.plugins[name] ~= nil
 end
 


### PR DESCRIPTION
## Description
Currently `M.have_plugin` only checks if the plugin name is in `spec.plugins`. When a user has `mini.nvim` installed that is not sufficient as its modules don't get enabled until their `setup` function is called. When they are setup, usually a global table for each module is present. For `mini.sessions` it's `_G.MiniSessions`.

Thus, it's better to check for the global table when `mini.nvim` is installed by a user to check if a module is actually setup.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #2630
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

