### PR TITLE
fix(image): restore image visibility when buffer returns to view

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -538,6 +538,9 @@ function M:update()
     self:hide()
     return
   end
+  if self.hidden then
+    self:show()
+  end
   self.img:place(self)
 
   self:debug("update")


### PR DESCRIPTION
When a buffer with an image was hidden (no open windows), and then shown again, the image would not render
   because the 'hidden' flag was never restored to false.

     This fix calls show() when the buffer becomes visible again, properly restoring the image visibility state.

     ## Description

     When switching between buffers in Neovim with snacks.nvim's image viewer enabled:
     1. Open an image file - image displays correctly ✅
     2. Switch to another buffer - the image buffer has no visible windows
        - `M:update()` calls `self:hide()` and sets `self.hidden = true`
     3. Return to the image buffer - the buffer is now visible again
        - `M:update()` is called with `#state.wins > 0` ✅
        - But `self.hidden` remains `true` ❌
     4. The `_render()` function checks `if self.hidden then` and renders empty text instead of the image ❌

     **Root Cause**: The `hidden` flag is set when the buffer is hidden, but never restored when it becomes
   visible again.

     **Fix**: In `M:update()`, after checking that windows exist (`#state.wins > 0`), check if the buffer was
   previously hidden and call `show()` to restore the visibility state.

     ## Related Issue(s)

     This is a fix for image disappearance when switching between buffers in snacks.nvim.

     ## Changes Made

     - Modified `lua/snacks/image/placement.lua`
     - Added 3 lines in `M:update()` to restore `show()` when buffer becomes visible

     ## Testing

     ✅ Tested on macOS with Kitty terminal
     - Open PNG/JPG image file → image displays
     - Switch to another buffer → buffer hidden correctly
     - Return to image buffer → image now displays correctly (previously was blank)
     - Repeated multiple times → consistently working

     ## Code Change

     ```lua
     if #state.wins == 0 then
       self:hide()
       return
     end
     if self.hidden then
       self:show()  -- ← Added: restore visibility when buffer becomes visible
     end
     self.img:place(self)