### PR TITLE
fix(image): improve anti-aliasing for LaTeX math expressions

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -155,7 +155,13 @@ In case of issues, make sure to run `:checkhealth snacks`.
     magick = {
       default = { "{src}[0]", "-scale", "1920x1080>" }, -- default for raster images
       vector = { "-density", 192, "{src}[{page}]" }, -- used by vector images like svg
-      math = { "-density", 192, "{src}[{page}]", "-trim" },
+      -- Use fixed background colors (#ffffff for light, #000000 for dark) to improve
+      -- anti-aliasing quality while maintaining cache reusability across different themes.
+      -- The background is later made transparent via ImageMagick's -transparent option.
+      math = function()
+        local bgcolor = vim.o.background == "light" and "#ffffff" or "#000000"
+        return { "-density", 192, "-background", bgcolor, "{src}[{page}]", "-flatten", "-fuzz", "2%", "-transparent", bgcolor, "-trim" }
+      end,
       pdf = { "-density", 192, "{src}[{page}]", "-background", "white", "-alpha", "remove", "-trim" },
     },
   },

--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -130,7 +130,13 @@ local defaults = {
     magick = {
       default = { "{src}[0]", "-scale", "1920x1080>" }, -- default for raster images
       vector = { "-density", 192, "{src}[{page}]" }, -- used by vector images like svg
-      math = { "-density", 192, "{src}[{page}]", "-trim" },
+      -- Use fixed background colors (#ffffff for light, #000000 for dark) to improve
+      -- anti-aliasing quality while maintaining cache reusability across different themes.
+      -- The background is later made transparent via ImageMagick's -transparent option.
+      math = function()
+        local bgcolor = vim.o.background == "light" and "#ffffff" or "#000000"
+        return { "-density", 192, "-background", bgcolor, "{src}[{page}]", "-flatten", "-fuzz", "2%", "-transparent", bgcolor, "-trim" }
+      end,
       pdf = { "-density", 192, "{src}[{page}]", "-background", "white", "-alpha", "remove", "-trim" },
     },
   },


### PR DESCRIPTION
## Description

Improves anti-aliasing quality for LaTeX math expressions on both light and dark backgrounds by using background-aware rendering during ImageMagick conversion.

Previously, LaTeX math was rendered with a transparent background, causing ImageMagick to default to white for anti-aliasing. This created white halos around math expressions on dark backgrounds.

The fix uses fixed background colors (#ffffff for light, #000000 for dark) based on `vim.o.background`, then makes the background transparent after proper anti-aliasing is applied.

## Related Issue(s)

- Fixes #2644

## Screenshots

before:
<img width="480" src="https://github.com/user-attachments/assets/c2d84f3a-2f91-45bd-99d2-a71a045b9c13" />

after:
<img width="480" src="https://github.com/user-attachments/assets/2b1ab61d-63fa-4460-8e9c-b9c639b1f10d" />

