### PR TITLE
fix(bigfile): Fix bigfile detection with symlinks

### DIFF
--- a/lua/snacks/bigfile.lua
+++ b/lua/snacks/bigfile.lua
@@ -42,7 +42,7 @@ function M.setup()
           if not path or not buf or vim.bo[buf].filetype == "bigfile" then
             return
           end
-          if path ~= vim.fs.normalize(vim.api.nvim_buf_get_name(buf)) then
+          if vim.uv.fs_realpath(path) ~= vim.fs.normalize(vim.api.nvim_buf_get_name(buf)) then
             return
           end
           local size = vim.fn.getfsize(path)


### PR DESCRIPTION
## Description
This is where the bug is
```
if path ~= vim.fs.normalize(vim.api.nvim_buf_get_name(buf)) then
   return
end
```
In the current code, if you open up a file whose path is a symlink (inside of Neovim not from the terminal), the path variable gets the symlink path, while the vim.api.nvim_buf_get_name(buf) returns the target path.  This causes a mismatch making the program mistakenly return.

The fix just uses `vim.uv.fs_realpath(path)` to translate it to the target path

## Example
This is my debugging messages after fixing it for the case that was causing me trouble
```
path    : /var/folders/dc/6mmnz_w549n7k146r10rsqfr0000gn/T/sourcekit-lsp/GeneratedInterfaces/SwiftUI.swiftinterface
buf name: /private/var/folders/dc/6mmnz_w549n7k146r10rsqfr0000gn/T/sourcekit-lsp/GeneratedInterfaces/SwiftUI.swiftinterface
Big file detected `/private/var/folders/dc/6mmnz_w549n7k146r10rsqfr0000gn/T/sourcekit-lsp/GeneratedInterfaces/SwiftUI.swiftinterface`.
Some Neovim features have been **disabled**.
```

