### PR TITLE
fix(picker/git_log): provide a dedicated highlight for dimmed conventional commit type

### DIFF
--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -190,8 +190,10 @@ function M.commit_message(item, picker)
   if type and body then
     local dimmed = vim.tbl_contains({ "chore", "bot", "build", "ci", "style", "test" }, type)
     msg_hl = dimmed and "SnacksPickerDimmed" or "SnacksPickerGitMsg"
-    ret[#ret + 1] =
-      { type, breaking ~= "" and "SnacksPickerGitBreaking" or dimmed and "SnacksPickerBold" or "SnacksPickerGitType" }
+    ret[#ret + 1] = {
+      type,
+      breaking ~= "" and "SnacksPickerGitBreaking" or dimmed and "SnacksPickerGitTypeDimmed" or "SnacksPickerGitType",
+    }
     if scope and scope ~= "" then
       ret[#ret + 1] = { scope, "SnacksPickerGitScope" }
     end


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

All formatting in the Git pickers use dedicated `SnackPickerGit*` highlight groups except the dimmed conventional commit type which is reusing `SnacksPickerBold`.
`SnacksPickerBold` is used for Markdown bold formatting and typically themed to be more visible than dimmed which is contradictory with the `git_log` usage/intent.

This PR simply use a dedicated `SnacksPickerGitTypeDimmed` instead to be consistent.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
N/A

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
N/A

