### PR TITLE
fix(lazygit): allow the config to have dicts within lists

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -165,23 +165,29 @@ local function update_config(opts)
     return type(val) == "string" and not val:find("^\"'`") and ("%q"):format(val) or val
   end
 
+  ---@param tbl any
+  ---@param indent number
+  ---@param sublist? boolean
   local function to_yaml(tbl, indent, sublist)
     indent = indent or 0
     local lines = {}
     for k, v in pairs(tbl) do
+      -- Print top level item
+      local kv_str = k .. (type(v) == "table" and ":" or ": " .. yaml_val(v))
+      -- The first item of a sublist needs '- ' one indent back
       if sublist then
         sublist = false
-        table.insert(
-          lines,
-          string.rep(" ", indent - 2) .. "- " .. k .. (type(v) == "table" and ":" or ": " .. yaml_val(v))
-        )
+        table.insert(lines, string.rep(" ", indent - 2) .. "- " .. kv_str)
       else
-        table.insert(lines, string.rep(" ", indent) .. k .. (type(v) == "table" and ":" or ": " .. yaml_val(v)))
+        table.insert(lines, string.rep(" ", indent) .. kv_str)
       end
+
+      -- Print any child items
       if type(v) == "table" then
         if (vim.islist or vim.tbl_islist)(v) then
           for _, item in ipairs(v) do
             if type(item) == "table" then
+              -- sublist
               vim.list_extend(lines, to_yaml(item, indent + 4, true))
             else
               table.insert(lines, string.rep(" ", indent + 2) .. "- " .. yaml_val(item))


### PR DESCRIPTION
## Description
Handle lazy git config with dicts/tables/sublists within lists. This allows for setting customCommands and some other things from the lua config.

This change makes it so if there is a list item that is itself a list, it's  treated as a special case of rendering a table where the first item is given a "- " at the start.

## Related Issue(s)

- Fixes #2582 

