### PR TITLE
fix(picker.git): properly handle file copy in git log

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -173,14 +173,14 @@ function M.log(opts, ctx)
           "--follow",
           "--name-status",
           "--pretty=format:''",
-          "--diff-filter=R",
+          "--diff-filter=RC",
           "--",
           file,
           opts
         ),
       }, ctx)(function(item)
         for _, text in ipairs(vim.split(item.text, "\0")) do
-          if text:find("^R%d%d%d$") then
+          if text:find("^[RC]%d%d%d$") then
             is_rename = true
           elseif is_rename then
             is_rename = false


### PR DESCRIPTION
## Description

This change is a followup to the change https://github.com/folke/snacks.nvim/issues/1154, because similar situation may happen when a file is copied.

This can be easily reproduced by doing this:

```
echo "test1" >file1.txt
git add . && git commit -a -m "first change"
echo "test2" >file1.txt
git add . && git commit -a -m "second change"

# copy the file to the file2.txt

cp file1.txt file2.txt
git add . && git commit -a -m "third change"

echo "test3" >file2.txt
git add . && git commit -a -m "fourth change"
```

Then one may inspect the log:

```
$ git log --name-status --oneline --follow -- file2.txt
4173ba0 (HEAD -> main) fourth change
M       file2.txt
5a74d25 third change
C100    file1.txt       file2.txt
b6c4d07 second change
M       file1.txt
276e31a first change
A       file1.txt
```

Note the change is of type `C` not `R` as technically this is not rename, but the `--follow` will follow the file history.

## Related Issue(s)

There is no issue for this particular change, but this is a followup to this one: https://github.com/folke/snacks.nvim/issues/1154

## Screenshots

This is **without the change**:

<img width="1161" height="826" alt="Screenshot 2026-01-21 at 09 34 20" src="https://github.com/user-attachments/assets/8b28afd4-f21a-40b9-933a-d770353ea8f8" />

This is with the change:

<img width="1161" height="823" alt="Screenshot 2026-01-21 at 09 34 58" src="https://github.com/user-attachments/assets/974e3f5b-2f28-4266-a0e5-c225d0170756" />

