### PR TITLE
fix(picker): correct Windows platform check for the `find` command

### DIFF
--- a/lua/snacks/picker/source/files.lua
+++ b/lua/snacks/picker/source/files.lua
@@ -15,7 +15,7 @@ local commands = {
   {
     cmd = { "find" },
     args = { ".", "-type", "f", "-not", "-path", "*/.git/*" },
-    enabled = vim.fn.has("win-32") == 0,
+    enabled = vim.fn.has("win32") == 0,
   },
 }
 


### PR DESCRIPTION
## Description

Fix invalid enable check for the `find` command that always evaluated to true.

## Related Issue(s)

N/A

## Screenshots

N/A
