### PR TITLE
feat(picker.select): add option to show or hide indexes

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -988,10 +988,12 @@ M.search_history = {
 --- Not meant to be used directly.
 ---@class snacks.picker.select.Config: snacks.picker.Config
 ---@field kinds? table<string, snacks.picker.Config|{}> custom snacks picker configs for specific `vim.ui.select` kinds
+---@field show_idx? boolean show indexes in the list (default: true)
 M.select = {
   items = {}, -- these are set dynamically
   main = { current = true },
   layout = { preset = "select" },
+  show_idx = true,
 }
 
 ---@class snacks.picker.smart.Config: snacks.picker.Config

--- a/lua/snacks/picker/format.lua
+++ b/lua/snacks/picker/format.lua
@@ -337,12 +337,16 @@ end
 ---@return snacks.picker.format
 function M.ui_select(opts)
   return function(item, picker)
-    local count = picker:count()
     local ret = {} ---@type snacks.picker.Highlight[]
-    local idx = tostring(item.idx)
-    idx = (" "):rep(#tostring(count) - #idx) .. idx
-    ret[#ret + 1] = { idx .. ".", "SnacksPickerIdx" }
-    ret[#ret + 1] = { " " }
+
+    local select_opts = picker.opts --[[@as snacks.picker.select.Config]]
+    if select_opts.show_idx ~= false then
+      local count = picker:count()
+      local idx = tostring(item.idx)
+      idx = (" "):rep(#tostring(count) - #idx) .. idx
+      ret[#ret + 1] = { idx .. ".", "SnacksPickerIdx" }
+      ret[#ret + 1] = { " " }
+    end
 
     if opts.kind == "codeaction" then
       ---@type lsp.Command|lsp.CodeAction, lsp.HandlerContext

--- a/lua/snacks/picker/select.lua
+++ b/lua/snacks/picker/select.lua
@@ -22,14 +22,19 @@ function M.select(items, opts, on_choice)
   ---@type snacks.picker.select.Config
   local picker_opts = {
     source = "select",
-    finder = function()
+    finder = function(picker_opts)
+      local select_opts = picker_opts --[[@as snacks.picker.select.Config]]
       ---@type snacks.picker.finder.Item[]
       local ret = {}
       for idx, item in ipairs(items) do
         local text = (opts.format_item or tostring)(item)
         ---@type snacks.picker.finder.Item
         local it = type(item) == "table" and setmetatable({}, { __index = item }) or {}
-        it.text = idx .. " " .. text
+        if select_opts.show_idx ~= false then
+          it.text = idx .. " " .. text
+        else
+          it.text = text
+        end
         it.item = item
         it.idx = idx
         ret[#ret + 1] = it


### PR DESCRIPTION
Hi, introduce the option `show_idx` to show (default) or hide the number indexes printed in front of each item in the picker of `vim.ui.select`.

Then we can disable the indexes:

```lua
opts.picker = {
  -- rest of the config
  sources = {
    select = {
      show_idx = false,
    },
  },

--  Or via vim.ui.select
vim.ui.select(items, {
  snacks = { show_idx = false }
}, callback)
``` 

This is useful for minimal UI for example, input hidden, no preview, just the title and the option list to navigate and select.

<img width="471" height="125" alt="image" src="https://github.com/user-attachments/assets/b4bcab7c-aafa-4de1-9a6a-de560739c49f" />
