### PR TITLE
feat(image): add support for Warp terminal

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -18,6 +18,7 @@ Terminal support:
 - [wezterm](https://wezfurlong.org/wezterm/)
   Wezterm has only limited support for the kitty graphics protocol.
   Inline image rendering is not supported.
+- [warp](https://www.warp.dev/)
 - [tmux](https://github.com/tmux/tmux)
   Snacks automatically tries to enable `allow-passthrough=on` for tmux,
   but you may need to enable it manually in your tmux configuration.

--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -18,7 +18,7 @@ local M = setmetatable({}, {
 })
 
 M.meta = {
-  desc = "Image viewer using Kitty Graphics Protocol, supported by `kitty`, `wezterm` and `ghostty`",
+  desc = "Image viewer using Kitty Graphics Protocol, supported by `kitty`, `wezterm`, `ghostty` and `warp`",
   needs_setup = true,
 }
 
@@ -308,7 +308,7 @@ function M.health()
   vim.wait(1500, function()
     return detected
   end, 10)
-  Snacks.health.have_tool({ "kitty", "wezterm", "ghostty" })
+  Snacks.health.have_tool({ "kitty", "wezterm", "ghostty", "warp" })
   local is_win = jit.os:find("Windows")
   if not Snacks.health.have_tool({ "magick", not is_win and "convert" or nil }) then
     Snacks.health.error("`magick` is required to convert images. Only PNG files will be displayed.")
@@ -374,7 +374,7 @@ function M.health()
     Snacks.health.warn("image viewer is enabled with `opts.force = true`. Use at your own risk")
   else
     Snacks.health.error("your terminal does not support the kitty graphics protocol")
-    Snacks.health.info("supported terminals: `kitty`, `wezterm`, `ghostty`")
+    Snacks.health.info("supported terminals: `kitty`, `wezterm`, `ghostty`, `warp`")
   end
 end
 

--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -24,6 +24,12 @@ local environments = {
     placeholders = false,
   },
   {
+    name = "warp",
+    env = { TERM_PROGRAM = "WarpTerminal" },
+    supported = true,
+    placeholders = false,
+  },
+  {
     name = "tmux",
     env = { TERM = "tmux", TMUX = true },
     setup = function()


### PR DESCRIPTION
## Description

This PR adds support for Warp terminal to the image viewer snack. Warp supports the Kitty Graphics Protocol, which allows it to display images using the same infrastructure as kitty, wezterm, and ghostty.

**Changes:**
- Added warp terminal environment detection (TERM_PROGRAM=WarpTerminal)
- Updated documentation to list warp as a supported terminal
- Updated health check to include warp in the list of supported terminals
- Configured placeholders as false (warp doesn't support inline placeholders)