### PR TITLE
fix(picker.actions): use win instead of buf

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -237,7 +237,7 @@ function M.insert(picker, _, action)
   ---@cast action snacks.picker.insert.Action
   if action.expr then
     local value = ""
-    vim.api.nvim_buf_call(picker.input.filter.current_buf, function()
+    vim.api.nvim_win_call(picker.input.filter.current_win, function()
       value = action.expr == "line" and vim.api.nvim_get_current_line() or vim.fn.expand(action.expr)
     end)
     vim.api.nvim_win_call(picker.input.win.win, function()


### PR DESCRIPTION
## Description
fix for https://github.com/folke/snacks.nvim/issues/2705
use the current window instead of the current buffer in `insert`

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #2705
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

