### PR TITLE
fix(picker): picker is closed immediately

### DIFF
--- a/lua/snacks/picker/core/picker.lua
+++ b/lua/snacks/picker/core/picker.lua
@@ -287,26 +287,28 @@ function M:attach()
     if vim.v.vim_did_enter == 0 then
       return
     end
-    if self.closed or Snacks.util.is_float() then
-      return
-    end
-    if self:is_focused() then
-      if preview then -- re-open preview when needed
-        self:toggle("preview", { enable = true })
-        preview = false
-      end
-      return
-    end
-    -- close main preview when auto_close is disabled
-    if self.opts.auto_close == false then
-      if self.preview.main and self.preview.win:valid() then
-        self:toggle("preview", { enable = false })
-        preview = true
-      end
-      return
-    end
-    -- close picker when we enter another window
+    -- schedule to allow other plugins to restore focus
+    -- https://github.com/nvim-mini/mini.nvim/issues/2255
     vim.schedule(function()
+      if self.closed or Snacks.util.is_float() then
+        return
+      end
+      if self:is_focused() then
+        if preview then -- re-open preview when needed
+          self:toggle("preview", { enable = true })
+          preview = false
+        end
+        return
+      end
+      -- close main preview when auto_close is disabled
+      if self.opts.auto_close == false then
+        if self.preview.main and self.preview.win:valid() then
+          self:toggle("preview", { enable = false })
+          preview = true
+        end
+        return
+      end
+      -- close picker when we enter another window
       self:close()
     end)
   end)


### PR DESCRIPTION
## Description

When a Snacks picker is opened after `mini.files`, it is closed immediately. nvim-mini/mini.nvim#2255

## Screenshots

### Before

```lua
-- Install `lazy.nvim` plugin manager
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not vim.uv.fs_stat(lazypath) then
	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
	local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
	if vim.v.shell_error ~= 0 then
		error("Error cloning lazy.nvim:\n" .. out)
	end
end
vim.opt.rtp:prepend(lazypath)

require("lazy").setup({
	{
		"folke/snacks.nvim",
		-- dir = "~/Developer/gh/folke/snacks.nvim",
		opts = { picker = {} },
	},
	{
		"nvim-mini/mini.files",
		opts = {},
	},
})

MiniFiles.open()
vim.defer_fn(function()
	Snacks.picker.files()
end, 500)
```

https://github.com/user-attachments/assets/25b2ac79-3ffa-435d-a124-db3933851541

### After

https://github.com/user-attachments/assets/f238d2f6-599f-4bf1-b55b-9ed41d902787

## AI Usage

The code was generated by Claude, but I manually reviewed and tested it.