### PR TITLE
feat(picker): implement cmdlineinsert action

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -658,6 +658,17 @@ function M.search(picker, item)
   end
 end
 
+function M.cmdlineinsert(picker, item)
+  picker:close()
+  if item then
+    vim.api.nvim_input(":")
+    vim.schedule(function()
+      vim.fn.setcmdline("e ".. item.text)
+      vim.api.nvim_input("<CR>")
+    end)
+  end
+end
+
 --- Tries to load the session, if it fails, it will open the picker.
 function M.load_session(picker, item)
   picker:close()


### PR DESCRIPTION
My original workflow for opening files in vim often involved the commandline history.

After switching to fuzzy file picker this method does not work anymore.

Bring this possibility back by allowing to open files via injecting :e <filename> <CR> into the commandline.

