### PR TITLE
fix(dashboard): wrap `nvim_del_augroup_by_id` with `pcall`

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -259,7 +259,7 @@ function D:init()
     buffer = self.buf,
     callback = function()
       self.fire("Closed")
-      vim.api.nvim_del_augroup_by_id(self.augroup)
+      pcall(vim.api.nvim_del_augroup_by_id, self.augroup)
     end,
   })
   vim.api.nvim_create_autocmd("WinEnter", {


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
This pull request makes a minor improvement to the `D:init()` function in `lua/snacks/dashboard.lua` by safely handling the deletion of an autocommand group. The change wraps the call to `vim.api.nvim_del_augroup_by_id` in a `pcall` to prevent errors if the group does not exist or has already been deleted.

## Related Issue(s)
- Fixes: #2724

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

