### PR TITLE
fix(explorer): support GIT_DIR worktrees and prevent git status overload

### DIFF
--- a/lua/snacks/explorer/git.lua
+++ b/lua/snacks/explorer/git.lua
@@ -9,13 +9,16 @@ local uv = vim.uv or vim.loop
 
 local CACHE_TTL = 15 * 60 -- 15 minutes
 
-M.state = {} ---@type table<string, {tick: number, last: number}>
+M.state = {} ---@type table<string, {tick: number, last: number, running?: boolean, pending?: boolean}>
 
 ---@param path string
 function M.refresh(path)
   for root in pairs(M.state) do
     if path == root or path:find(root .. "/", 1, true) == 1 then
       M.state[root].last = 0
+      if M.state[root].running then
+        M.state[root].pending = true
+      end
     end
   end
 end
@@ -45,12 +48,30 @@ function M.update(cwd, opts)
   local now = os.time()
   M.state[root] = M.state[root] or { tick = 0, last = 0 }
   local state = M.state[root]
+  if state.running then
+    state.pending = true
+    return
+  end
   if now - state.last < ttl then
     return
   end
   state.last = now
   state.tick = state.tick + 1
   local tick = state.tick
+  state.running = true
+
+  local status_args = {
+    "--no-pager",
+    "--no-optional-locks",
+    "status",
+    "--porcelain=v1",
+    "--ignored=matching",
+    "-z",
+    opts.untracked and "-unormal" or "-uno",
+  }
+  if cwd ~= root and cwd:find(root .. "/", 1, true) == 1 then
+    vim.list_extend(status_args, { "--", cwd:sub(#root + 2) })
+  end
 
   local output = ""
   local stdout = assert(uv.new_pipe())
@@ -59,20 +80,24 @@ function M.update(cwd, opts)
     stdio = { nil, stdout, nil },
     cwd = root,
     hide = true,
-    args = {
-      "--no-pager",
-      "--no-optional-locks",
-      "status",
-      "--porcelain=v1",
-      "--ignored=matching",
-      "-z",
-      opts.untracked and "-unormal" or "-uno",
-    },
+    args = status_args,
   }, function()
+    local s = M.state[root]
+    if s and s.tick == tick then
+      s.running = false
+      if s.pending then
+        s.pending = false
+        s.last = 0
+        vim.schedule(function()
+          M.update(cwd, opts)
+        end)
+      end
+    end
     handle:close()
   end)
 
   if not handle then
+    state.running = false
     return M._update(cwd, {})
   end
 

--- a/lua/snacks/explorer/watch.lua
+++ b/lua/snacks/explorer/watch.lua
@@ -88,9 +88,10 @@ function M.watch()
   for cwd in pairs(cwds) do
     -- Watch git index
     local root = Snacks.git.get_root(cwd)
-    if root then
-      used[root .. "/.git"] = true
-      M.start(root .. "/.git", function(file)
+    local git_dir = Snacks.git.get_dir(cwd)
+    if root and git_dir then
+      used[git_dir] = true
+      M.start(git_dir, function(file)
         if vim.fs.basename(file) == "index" then
           Git.refresh(root)
           M.refresh()

--- a/lua/snacks/git.lua
+++ b/lua/snacks/git.lua
@@ -1,5 +1,6 @@
 ---@class snacks.git
 local M = {}
+local uv = vim.uv or vim.loop
 
 M.meta = {
   desc = "Git utilities",
@@ -15,11 +16,61 @@ Snacks.config.style("blame_line", {
 })
 
 local git_cache = {} ---@type table<string, boolean>
+local git_dir_cache = {} ---@type table<string, string|false>
 local function is_git_root(dir)
   if git_cache[dir] == nil then
-    git_cache[dir] = (vim.uv or vim.loop).fs_stat(dir .. "/.git") ~= nil
+    git_cache[dir] = uv.fs_stat(dir .. "/.git") ~= nil
   end
   return git_cache[dir]
+end
+
+---@param root string
+---@return string?
+local function get_root_git_dir(root)
+  local cached = git_dir_cache[root]
+  if cached ~= nil then
+    return cached or nil
+  end
+
+  local env_work_tree = os.getenv("GIT_WORK_TREE")
+  local env_git_dir = os.getenv("GIT_DIR")
+  if env_work_tree and env_work_tree ~= "" and env_git_dir and env_git_dir ~= "" then
+    if svim.fs.normalize(env_work_tree) == root then
+      local git_dir = svim.fs.normalize(env_git_dir, { _fast = true })
+      if not git_dir:match("^/") then
+        git_dir = svim.fs.normalize(root .. "/" .. git_dir, { _fast = true })
+      end
+      git_dir_cache[root] = git_dir
+      return git_dir
+    end
+  end
+
+  local dot_git = root .. "/.git"
+  local stat = uv.fs_stat(dot_git)
+  if stat and stat.type == "directory" then
+    git_dir_cache[root] = dot_git
+    return dot_git
+  end
+
+  if stat and stat.type == "file" then
+    local fd = uv.fs_open(dot_git, "r", 438)
+    if fd then
+      local git_stat = uv.fs_fstat(fd)
+      local data = git_stat and uv.fs_read(fd, git_stat.size, 0) or nil
+      uv.fs_close(fd)
+      local git_dir = data and data:match("^gitdir:%s*(.-)%s*$")
+      if git_dir and git_dir ~= "" then
+        git_dir = svim.fs.normalize(git_dir, { _fast = true })
+        if not git_dir:match("^/") then
+          git_dir = svim.fs.normalize(root .. "/" .. git_dir, { _fast = true })
+        end
+        git_dir_cache[root] = git_dir
+        return git_dir
+      end
+    end
+  end
+
+  git_dir_cache[root] = false
 end
 
 --- Gets the git root for a buffer or path.
@@ -29,7 +80,7 @@ end
 function M.get_root(path)
   path = path or 0
   path = type(path) == "number" and vim.api.nvim_buf_get_name(path) or path --[[@as string]]
-  path = path == "" and (vim.uv or vim.loop).cwd() or path
+  path = path == "" and uv.cwd() or path
   path = svim.fs.normalize(path)
 
   if is_git_root(path) then
@@ -42,7 +93,18 @@ function M.get_root(path)
     end
   end
 
-  return os.getenv("GIT_WORK_TREE")
+  local work_tree = os.getenv("GIT_WORK_TREE")
+  return work_tree and work_tree ~= "" and svim.fs.normalize(work_tree) or nil
+end
+
+---@param path? number|string buffer or path
+---@return string?
+function M.get_dir(path)
+  local root = M.get_root(path)
+  if not root then
+    return
+  end
+  return get_root_git_dir(root)
 end
 
 --- Show git log for the current line.


### PR DESCRIPTION
This fixes Explorer git integration for detached repositories (like YADM) by resolving the real git directory from GIT metadata/env instead of assuming `<root>/.git`. It also avoids overlapping status refreshes and scopes git status checks to the current subtree, which prevents high CPU usage and restores correct file status indicators.