### PR TITLE
feat(layout): set different ft for explorer layout

### DIFF
--- a/lua/snacks/layout.lua
+++ b/lua/snacks/layout.lua
@@ -21,6 +21,7 @@ M.meta = {
 ---@class snacks.layout.Box: snacks.layout.Win,{}
 ---@field box "horizontal" | "vertical"
 ---@field id? number
+---@field root_ft? string
 ---@field [number] snacks.layout.Win | snacks.layout.Box children
 
 ---@alias snacks.layout.Widget snacks.layout.Win | snacks.layout.Box
@@ -50,12 +51,13 @@ function M.new(opts)
   self.wins = self.opts.wins or {}
   self.box_wins = {}
   self.opts.layout.zindex = Snacks.win.zindex(self.opts.layout.zindex) + 2
+  local inner
 
   -- wrap the split layout in a vertical box
   -- this is needed since a simple split window can't have borders/titles
   if self.opts.layout.position and self.opts.layout.position ~= "float" then
     self.split = true
-    local inner = self.opts.layout
+    inner = self.opts.layout
     self.opts.layout = {
       zindex = 30,
       box = "vertical",
@@ -91,7 +93,10 @@ function M.new(opts)
           noautocmd = true,
           backdrop = backdrop,
           zindex = (self.opts.layout.zindex or 50) + box.depth,
-          bo = { filetype = "snacks_layout_box", buftype = "nofile" },
+          bo = {
+            filetype = inner and inner.root_ft or self.opts.layout.root_ft or "snacks_layout_box",
+            buftype = "nofile",
+          },
           w = { snacks_layout = true },
           border = box.border,
         }))

--- a/lua/snacks/picker/config/layouts.lua
+++ b/lua/snacks/picker/config/layouts.lua
@@ -178,6 +178,7 @@ M.vscode = {
 
 M.left = M.sidebar
 M.right = { preset = "sidebar", layout = { position = "right" } }
+M.explorer = { preset = "sidebar", layout = { root_ft = "snacks_explorer" } }
 M.top = { preset = "ivy", layout = { position = "top" } }
 M.bottom = { preset = "ivy", layout = { position = "bottom" } }
 

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -62,7 +62,7 @@ M.explorer = {
   focus = "list",
   auto_close = false,
   jump = { close = false },
-  layout = { preset = "sidebar", preview = false },
+  layout = { preset = "explorer", preview = false },
   -- to show the explorer to the right, add the below to
   -- your config under `opts.picker.sources.explorer`
   -- layout = { layout = { position = "right" } },


### PR DESCRIPTION
## Description
This adds a specific filetype for Explorer root box. See #2097 for the reason it's needed. Although this only happens with `barbar.nvim` and not `bufferline.nvim`, so it might be implementation related, I think it's still useful to have a separate ft for the Explorer root box, as there might be other cases where an explicit filetype would be better for calculating offset, rather than the generic `snacks_layout_box` for all pickers.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #2097
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

