### PR TITLE
feat(picker): add `focus` option to `resume()`

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -778,6 +778,11 @@ function M.cycle_win(picker)
     end
   end
   win = wins[idx % #wins + 1] or 1 -- cycle
+  for name, layout in pairs(picker.layout.wins) do
+    if layout.win == win then
+      picker.init_opts.focus = name
+    end
+  end
   vim.api.nvim_set_current_win(win)
 end
 

--- a/lua/snacks/picker/init.lua
+++ b/lua/snacks/picker/init.lua
@@ -53,6 +53,7 @@ M.meta = {
 ---@field source? string
 ---@field include? string[]
 ---@field exclude? string[]
+---@field focus? "input"|"list"
 
 -- create actual picker functions for autocomplete
 vim.defer_fn(function()

--- a/lua/snacks/picker/resume.lua
+++ b/lua/snacks/picker/resume.lua
@@ -58,6 +58,9 @@ function M.resume(opts)
 
   for _, source in ipairs(sources) do
     if M.state[source] and not vim.tbl_contains(opts.exclude or {}, source) then
+      if opts.focus then
+        M.state[source].opts.focus = opts.focus
+      end
       states[#states + 1] = M.state[source]
     end
   end


### PR DESCRIPTION
## Description
Adds a `focus` field to `Snacks.picker.resume()` to explicitly define which window to focus. Additionally, I've added the functionality in `cycle_win` action to store the current window focused in `picker.init_opts`, since that's what's used in `resume()` states in order to provide the same functionality.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Closes #2726
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

