### PR TITLE
fix(picker): add `value=true` to grep source

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -498,6 +498,9 @@ M.grep = {
   show_empty = true,
   live = true, -- live grep by default
   supports_live = true,
+  toggles = {
+    regex = { value = true },
+  },
 }
 
 ---@type snacks.picker.grep.Config|{}


### PR DESCRIPTION
## Description
`value = true` is not set for the `regex` toggle in grep source.

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

This is how it looks like currently
**BEFORE**
<img width="2041" height="1029" alt="2026-02-24_19-29_1" src="https://github.com/user-attachments/assets/08a2cb47-991a-4ff0-bc99-c2a77994b22c" />
<img width="2056" height="1036" alt="2026-02-24_19-30" src="https://github.com/user-attachments/assets/07a94548-ccaf-4e41-b01e-695caa3bcc14" />
Here you see that `.` matches the parenthesis after `pcall` but the `R` toggle is not on. In the second pic `R` toggle is on but `.` matches nothing as it is actually translated as a literal `.` character.

**AFTER**
<img width="2038" height="1033" alt="2026-02-24_19-28" src="https://github.com/user-attachments/assets/b82a8d83-f26e-4203-8755-07d790b68c70" />
<img width="2046" height="1031" alt="2026-02-24_19-29" src="https://github.com/user-attachments/assets/19d64f38-6955-4b23-a4ad-d945f16bfcec" />
Here you can see correct show of `R` toggle.