### PR TITLE
fix(grep): remove `MATCH_SEP` before sending to notify

### DIFF
--- a/lua/snacks/picker/source/grep.lua
+++ b/lua/snacks/picker/source/grep.lua
@@ -122,14 +122,15 @@ function M.grep(opts, ctx)
         item.cwd = cwd
         -- Split on NUL byte (which comes from rg's -0 flag)
         local file_sep = item.text:find("\0")
+        local file = item.text:sub(1, file_sep - 1)
+        local rest = item.text:sub(file_sep + 1)
+        item.text = file .. ":" .. rest:gsub(MATCH_SEP, "")
         if not file_sep then
           if not item.text:match("WARNING") then
             Snacks.notify.error("invalid grep output:\n" .. item.text)
           end
           return false
         end
-        local file = item.text:sub(1, file_sep - 1)
-        local rest = item.text:sub(file_sep + 1)
         ---@type string?, string?, string?
         local line, col, text = rest:match("^(%d+):(%d+):(.*)$")
         if not (line and col and text) then
@@ -138,7 +139,6 @@ function M.grep(opts, ctx)
           end
           return false
         end
-        item.text = file .. ":" .. rest:gsub(MATCH_SEP, "")
 
         -- indices of matches
         local from = tonumber(col)


### PR DESCRIPTION
## Description
See https://github.com/LazyVim/LazyVim/issues/7025. I tracked it to `notify` not being able to parse the `MATCH_SEP`, presumably because the output returned by `rg` contains bytes for the emojis used and considers it a BLOB instead of a String.

Not sure if this is the best solution, but at least we can get the `Invalid grep output` notification now and see the offending file. For me it was `stylua.toml` and `lazyvim.json` which did not seem to have proper line endings at end of file (thus the last line did not contain a `col` field, but after being formatted they both had a `col` field). After writing to the files and them being formatted, the error disappeared.

We just move the modification of `item.text` before passing it to `notify`.

PS: You might want to also reformat the `stylua.toml` in LazyVim starter template, so that new users don't run into this. And I believe in `LazyVim.json.save()` we might need to add `f.write("\n")` before closing the handler in order to also avoid this each time a new Extra is enabled/disabled (but that might also depend on `<EOL>` for different OS).

PS2: Or maybe you find a better way to implement this on Snacks side that avoids these problems.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
https://github.com/LazyVim/LazyVim/issues/7025
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

