### PR TITLE
fix(indent): nvim_buf_call -> nvim_win_call

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -194,7 +194,7 @@ local function get_state(win, buf, top, bottom)
     is_current = win == vim.api.nvim_get_current_win(),
     top = top,
     bottom = bottom,
-    leftcol = vim.api.nvim_buf_call(buf, vim.fn.winsaveview).leftcol --[[@as number]],
+    leftcol = vim.api.nvim_win_call(win, vim.fn.winsaveview).leftcol --[[@as number]],
     shiftwidth = vim.bo[buf].shiftwidth,
     indents = prev and prev.indents or { [0] = 0 },
     blanks = prev and prev.blanks or {},


### PR DESCRIPTION
Wrong nvim_buf_call on winsaveview()

since it require curwin:
https://github.com/neovim/neovim/blob/ed8fbd2e2992cb264cb62585098a1c7acc5c4585/src/nvim/eval/window.c#L933-L948

