### PR TITLE
feat(lazygit): Switch to JSON encoding for config write

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -157,32 +157,7 @@ local function update_config(opts)
   end
 
   local config = vim.tbl_deep_extend("force", { gui = { theme = theme } }, opts.config or {})
-
-  local function yaml_val(val)
-    if type(val) == "boolean" then
-      return tostring(val)
-    end
-    return type(val) == "string" and not val:find("^\"'`") and ("%q"):format(val) or val
-  end
-
-  local function to_yaml(tbl, indent)
-    indent = indent or 0
-    local lines = {}
-    for k, v in pairs(tbl) do
-      table.insert(lines, string.rep(" ", indent) .. k .. (type(v) == "table" and ":" or ": " .. yaml_val(v)))
-      if type(v) == "table" then
-        if (vim.islist or vim.tbl_islist)(v) then
-          for _, item in ipairs(v) do
-            table.insert(lines, string.rep(" ", indent + 2) .. "- " .. yaml_val(item))
-          end
-        else
-          vim.list_extend(lines, to_yaml(v, indent + 2))
-        end
-      end
-    end
-    return lines
-  end
-  vim.fn.writefile(to_yaml(config), opts.theme_path)
+  vim.fn.writefile({vim.json.encode(config)}, opts.theme_path)
   dirty = false
 end
 


### PR DESCRIPTION
JSON is also a valid YAML. Replaced custom YAML serialization with JSON encoding for config.

## Description

Snacks does not have a full yaml parser, use `vim.json.encode` for better compatibility.

## Related Issue(s)

No.

## Screenshots

No.

