### PR TITLE
fix(picker): preserve previewed randomized colorscheme state on confirm

### DIFF
--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -124,10 +124,16 @@ M.colorschemes = {
   preview = "colorscheme",
   preset = "vertical",
   confirm = function(picker, item)
-    picker:close()
+    local hidden_preview = vim.tbl_contains(picker.resolved_layout.hidden or {}, "preview")
     if item then
       picker.preview.state.colorscheme = nil
+      if hidden_preview then
+        vim.schedule(function()
+          vim.cmd("colorscheme " .. item.text)
+        end)
+      end
     end
+    picker:close()
   end,
 }
 


### PR DESCRIPTION
  ## Summary

  The colorscheme picker preview already applies the selected colorscheme.

  For randomized colorschemes like `randomhue`, applying `:colorscheme`
  again on confirm can produce a different result than the one shown in
  preview.

  This changes the confirm path to keep the previewed state instead of
  reapplying the colorscheme.

  ## Repro

  1. Open `Snacks.picker.colorschemes()`
  2. Preview `randomhue`
  3. Confirm the selection
  4. The final colors differ from the preview

  ## Verification

  1. Preview `randomhue`
  2. Confirm the selection
  3. The final colors match the preview

  Regular deterministic colorschemes continue to behave the same.
