### PR TITLE
feat(gitbrowse): add support for Codeberg

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -73,6 +73,12 @@ local defaults = {
       permalink = "/tree/{commit}/item/{file}#L{line_start}",
       commit = "/commit/{commit}",
     },
+    ["codeberg%.org"] = {
+      branch = "/src/branch/{branch}",
+      file = "/src/branch/{branch}/{file}#L{line_start}-L{line_end}",
+      permalink = "/src/commit/{commit}/{file}#L{line_start}-L{line_end}",
+      commit = "/commit/{commit}",
+    },
   },
 }
 


### PR DESCRIPTION
## Description
Adds support for using `gitbrowse` with [Codeberg](https://codeberg.org) repos.

## Related Issue(s)
Closes https://github.com/folke/snacks.nvim/issues/2072

