### PR TITLE
fix(grep): guard file_sep nil before arithmetic

### DIFF
--- a/lua/snacks/picker/source/grep.lua
+++ b/lua/snacks/picker/source/grep.lua
@@ -122,23 +122,23 @@ function M.grep(opts, ctx)
         item.cwd = cwd
         -- Split on NUL byte (which comes from rg's -0 flag)
         local file_sep = item.text:find("\0")
-        local file = item.text:sub(1, file_sep - 1)
-        local rest = item.text:sub(file_sep + 1)
-        item.text = file .. ":" .. rest:gsub(MATCH_SEP, "")
         if not file_sep then
           if not item.text:match("WARNING") then
             Snacks.notify.error("invalid grep output:\n" .. item.text)
           end
           return false
         end
+        local file = item.text:sub(1, file_sep - 1)
+        local rest = item.text:sub(file_sep + 1)
         ---@type string?, string?, string?
         local line, col, text = rest:match("^(%d+):(%d+):(.*)$")
         if not (line and col and text) then
           if not item.text:match("WARNING") then
-            Snacks.notify.error("invalid grep output:\n" .. item.text)
+            Snacks.notify.error("invalid grep output:\n" .. item.text:sub(1, file_sep - 1) .. ":" .. item.text:sub(file_sep + 1))
           end
           return false
         end
+        item.text = file .. ":" .. rest:gsub(MATCH_SEP, "")
 
         -- indices of matches
         local from = tonumber(col)


### PR DESCRIPTION
## Problem

When `rg` outputs a line that does **not** contain a NUL byte separator (e.g. binary-file notices, warning messages, or any non-conforming `rg` output), `item.text:find("\0")` returns `nil`.

The existing nil guard for `file_sep` was placed **after** the lines that perform arithmetic on it, making it unreachable in the error case:

```lua
local file_sep = item.text:find("\0")
local file = item.text:sub(1, file_sep - 1)  -- 💥 crashes here if file_sep is nil
local rest = item.text:sub(file_sep + 1)
item.text = file .. ":" .. rest:gsub(MATCH_SEP, "")
if not file_sep then  -- never reached
  ...
end
```

This produces an unhandled async error:

```
snacks/picker/source/grep.lua:125: attempt to perform arithmetic on local 'file_sep' (a nil value)
```

## Fix

Move the `if not file_sep then` guard to immediately after `find()`, before any arithmetic on `file_sep`:

```lua
local file_sep = item.text:find("\0")
if not file_sep then
  if not item.text:match("WARNING") then
    Snacks.notify.error("invalid grep output:\n" .. item.text)
  end
  return false
end
local file = item.text:sub(1, file_sep - 1)  -- safe
local rest = item.text:sub(file_sep + 1)      -- safe
```

## Trigger conditions

- `rg` encountering binary files (emits `"Binary file <path> matches"` without NUL)
- `rg` warning lines about unreadable paths
- Any `rg` output line that doesn't follow the `filename\0line:col:match` format