### PR TITLE
fix(rename): use colon syntax for LSP client methods and update get_clients

### DIFF
--- a/lua/snacks/picker/source/lsp/init.lua
+++ b/lua/snacks/picker/source/lsp/init.lua
@@ -30,39 +30,6 @@ function M.symbol_kind(kind)
   return kinds[kind] or "Unknown"
 end
 
---- Neovim 0.11 uses a lua class for clients, while older versions use a table.
---- Wraps older style clients to be compatible with the new style.
----@param client vim.lsp.Client
----@return vim.lsp.Client
-local function wrap(client)
-  local meta = getmetatable(client)
-  if meta and meta.request then
-    return client
-  end
-  ---@diagnostic disable-next-line: undefined-field
-  if client.wrapped then
-    return client
-  end
-  local methods = { "request", "supports_method", "cancel_request", "notify" }
-  -- old style
-  return setmetatable({ wrapped = true }, {
-    __index = function(_, k)
-      if k == "supports_method" then
-        -- supports_method doesn't support the bufnr argument
-        return function(_, method)
-          return client[k](method)
-        end
-      end
-      if vim.tbl_contains(methods, k) then
-        return function(_, ...)
-          return client[k](...)
-        end
-      end
-      return client[k]
-    end,
-  })
-end
-
 ---@param item snacks.picker.finder.Item
 ---@param result lsp.Loc
 ---@param client vim.lsp.Client
@@ -86,7 +53,7 @@ end
 function M.get_clients(buf, method)
   ---@param client vim.lsp.Client
   local clients = vim.tbl_map(function(client)
-    return wrap(client)
+    return Snacks.util.wrap(client)
     ---@diagnostic disable-next-line: deprecated
   end, (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = buf }))
   ---@param client vim.lsp.Client
@@ -195,7 +162,7 @@ function R:request(buf, method, params, cb)
     self:track_cancel() -- setup autocmd here, since this must be called in the main loop
 
     ---@diagnostic disable-next-line: param-type-mismatch
-    local clients = type(buf) == "number" and M.get_clients(buf, method) or { wrap(buf) }
+    local clients = type(buf) == "number" and M.get_clients(buf, method) or { Snacks.util.wrap(buf) }
 
     self.pending = self.pending + #clients
     for _, client in ipairs(clients) do

--- a/lua/snacks/rename.lua
+++ b/lua/snacks/rename.lua
@@ -92,10 +92,13 @@ function M.on_rename_file(from, to, rename)
     newUri = vim.uri_from_fname(to),
   } } }
 
-  local clients = vim.lsp.get_clients()
+  local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  local clients = get_clients()
+
   for _, client in ipairs(clients) do
-    if client:supports_method("workspace/willRenameFiles") then
-      local resp = client:request_sync("workspace/willRenameFiles", changes, 1000, 0)
+    local wrapped = Snacks.util.wrap(client)
+    if wrapped:supports_method("workspace/willRenameFiles") then
+      local resp = wrapped:request_sync("workspace/willRenameFiles", changes, 1000, 0)
       if resp and resp.result ~= nil then
         vim.lsp.util.apply_workspace_edit(resp.result, client.offset_encoding)
       end
@@ -107,8 +110,9 @@ function M.on_rename_file(from, to, rename)
   end
 
   for _, client in ipairs(clients) do
-    if client:supports_method("workspace/didRenameFiles") then
-      client:notify("workspace/didRenameFiles", changes)
+    local wrapped = Snacks.util.wrap(client)
+    if wrapped:supports_method("workspace/didRenameFiles") then
+      wrapped:notify("workspace/didRenameFiles", changes)
     end
   end
 end

--- a/lua/snacks/util/init.lua
+++ b/lua/snacks/util/init.lua
@@ -492,4 +492,37 @@ function M.path_type(path)
   return "file"
 end
 
+--- Neovim 0.11 uses a lua class for clients, while older versions use a table.
+--- Wraps older style clients to be compatible with the new style.
+---@param client vim.lsp.Client
+---@return vim.lsp.Client
+function M.wrap(client)
+  local meta = getmetatable(client)
+  if meta and meta.request then
+    return client
+  end
+  ---@diagnostic disable-next-line: undefined-field
+  if client.wrapped then
+    return client
+  end
+  local methods = { "request", "supports_method", "cancel_request", "notify" }
+  -- old style
+  return setmetatable({ wrapped = true }, {
+    __index = function(_, k)
+      if k == "supports_method" then
+        -- supports_method doesn't support the bufnr argument
+        return function(_, method)
+          return client[k](method)
+        end
+      end
+      if vim.tbl_contains(methods, k) then
+        return function(_, ...)
+          return client[k](...)
+        end
+      end
+      return client[k]
+    end,
+  })
+end
+
 return M


### PR DESCRIPTION
## Description

This PR fixes deprecation warnings appearing in Neovim nightly (0.11+) when renaming files. 

Changes:
- Replaced `client.supports_method`, `client.request_sync`, and `client.notify` with the method call syntax `client:method(...)`.
- Replaced the deprecated `vim.lsp.get_active_clients()` with `vim.lsp.get_clients()`.

These changes align with the latest Neovim LSP API requirements.

## Related Issue(s)

Fixes deprecation warnings reported by `:checkhealth`.

## Screenshots
N/A (LSP API update)