### PR TITLE
feat(explorer): add explorer_add_cwd action

### DIFF
--- a/doc/snacks.nvim-picker.txt
+++ b/doc/snacks.nvim-picker.txt
@@ -1266,6 +1266,7 @@ EXPLORER                                 *snacks.nvim-picker-sources-explorer*
             ["l"] = "confirm",
             ["h"] = "explorer_close", -- close directory
             ["a"] = "explorer_add",
+            ["A"] = "explorer_add_cwd",
             ["d"] = "explorer_del",
             ["r"] = "explorer_rename",
             ["c"] = "explorer_copy",

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -1041,6 +1041,7 @@ Neovim commands
         ["l"] = "confirm",
         ["h"] = "explorer_close", -- close directory
         ["a"] = "explorer_add",
+        ["A"] = "explorer_add_cwd",
         ["d"] = "explorer_del",
         ["r"] = "explorer_rename",
         ["c"] = "explorer_copy",

--- a/lua/snacks/explorer/actions.lua
+++ b/lua/snacks/explorer/actions.lua
@@ -197,14 +197,14 @@ function M.actions.explorer_git_prev(picker, item)
   end
 end
 
-function M.actions.explorer_add(picker)
+local function explorer_add_to(picker, base)
   Snacks.input({
     prompt = 'Add a new file or directory (directories end with a "/")',
   }, function(value)
-    if not value or value:find("^%s$") then
+    if not value or value:find("^%s*$") then
       return
     end
-    local path = svim.fs.normalize(picker:dir() .. "/" .. value)
+    local path = svim.fs.normalize(base .. "/" .. value)
     local is_file = value:sub(-1) ~= "/"
     local dir = is_file and vim.fs.dirname(path) or path
     if is_file and uv.fs_stat(path) then
@@ -213,12 +213,23 @@ function M.actions.explorer_add(picker)
     end
     vim.fn.mkdir(dir, "p")
     if is_file then
-      io.open(path, "w"):close()
+      local f = io.open(path, "w")
+      if f then
+        f:close()
+      end
     end
     Tree:open(dir)
     Tree:refresh(dir)
     M.update(picker, { target = path })
   end)
+end
+
+function M.actions.explorer_add(picker)
+  explorer_add_to(picker, picker:dir())
+end
+
+function M.actions.explorer_add_cwd(picker)
+  explorer_add_to(picker, picker:cwd())
 end
 
 function M.actions.explorer_rename(picker, item)

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -81,6 +81,7 @@ M.explorer = {
         ["l"] = "confirm",
         ["h"] = "explorer_close", -- close directory
         ["a"] = "explorer_add",
+        ["A"] = "explorer_add_cwd",
         ["d"] = "explorer_del",
         ["r"] = "explorer_rename",
         ["c"] = "explorer_copy",


### PR DESCRIPTION
* Added a new action `explorer_add_cwd` that allows users to add files or directories in the current working directory instead of selected directory (accessible via the `A` keybinding in explorer mode).
* Refactored the file/directory creation logic by introducing a shared helper function `explorer_add_to`, used by both `explorer_add` and the new `explorer_add_cwd` actions.