### PR TITLE
fix(snacks.input): don't trigger the bell when the input window gets closed

### DIFF
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -1018,7 +1018,7 @@ function M:on_close()
   -- Go back to the previous window when closing,
   -- and it's the current window
   if vim.api.nvim_get_current_win() == self.win then
-    pcall(vim.cmd.wincmd, "p")
+    vim.cmd("silent! wincmd p")
   end
 end
 


### PR DESCRIPTION
## Description

When pressing `<esc>` or `<CR>` within the snacks.input window, the window starts being closed from the context of an `<expr>` mapping, when the textlock is active, so as you know, some actions are impossible. One of them is execution of `wincmd p` from the `snacks.win:on_close` method. It was wrapped in `pcall()`, which silences the thrown errors, but does not silence the bell, unlike `:silent!`.

## Related Issue(s)

N/A

## Screenshots

N/A
