### PR TITLE
docs(dashboard): remove outdated preset.keys function documentation

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -87,7 +87,6 @@ local defaults = {
     pick = nil,
     -- Used by the `keys` section to show keymaps.
     -- Set your custom keymaps here.
-    -- When using a function, the `items` argument are the default keymaps.
     -- stylua: ignore
     ---@type snacks.dashboard.Item[]
     keys = {


### PR DESCRIPTION
## Description

This is a very small documentation change, during a previous commit (0b9e09cbd97c178ebe5db78fd373448448c5511b) the option to pass a function to the dashboard keys config was removed.

The comment about that being an option was however still present, sending me on a small 15 minute hunt to find it 😅. This should hopefully prevent anyone from doing the same thing in the future.

## Related Issue(s)

N/A

## Screenshots

N/A
