### PR TITLE
fix(picker): avoid crash on multi-byte lines in resolve_loc

### DIFF
--- a/lua/snacks/picker/util/init.lua
+++ b/lua/snacks/picker/util/init.lua
@@ -399,7 +399,7 @@ function M.resolve_loc(item, buf)
       return
     end
     local line = lines[pos.line + 1]
-    local col = line and M.str_byteindex(line, pos.character, item.loc.encoding) or pos.character
+    local col = line and M.str_byteindex(line, pos.character, item.loc.encoding, false) or pos.character
     return { pos.line + 1, col }
   end
   item.pos = resolve(item.loc.range["start"])


### PR DESCRIPTION
## Problem

When using `Snacks.picker.lsp_symbols()` on files containing multi-byte characters (e.g. Chinese comments in `.proto` files), navigating the picker results with `<C-j>`/`<C-k>` crashes with:

```
E5108: Lua: vim/_core/editor.lua:0: index out of range
  vim/_core/editor.lua: in function 'str_byteindex'
  .../snacks.nvim/lua/snacks/picker/util/init.lua:402: in function 'resolve'
```

## Root Cause

In `resolve_loc()`, `M.str_byteindex` is called without the `strict_indexing` parameter:

```lua
local col = line and M.str_byteindex(line, pos.character, item.loc.encoding) or pos.character
```

When an LSP server (e.g. clangd) returns a `range.end.character` that exceeds the UTF-16 length of a line — which is common with CJK/multi-byte characters — `vim.str_byteindex` in Neovim 0.10+ raises `"index out of range"` because `strict_indexing` defaults to `true`.

The fix in #2389 (commit 46917d0) correctly added the `strict_indexing` parameter to `M.str_byteindex`, but the call site in `resolve_loc` never passes it.

## Fix

Pass `strict_indexing=false` so out-of-range indexes are clamped to the string end:

```lua
local col = line and M.str_byteindex(line, pos.character, item.loc.encoding, false) or pos.character
```

## Reproduction

1. Open a `.proto` file with Chinese comments (or any file with CJK characters)
2. Run `:lua Snacks.picker.lsp_symbols()`
3. Navigate with `<C-j>`/`<C-k>`
4. Observe crash on items whose range spans multi-byte characters