### PR TITLE
fix(image): handle tmux extended-keys always

### DIFF
--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -256,7 +256,7 @@ function M._detect(cb)
     -- Workaround: Query tmux directly for the terminal name instead of sending escape sequences.
     -- See: https://github.com/folke/snacks.nvim/issues/2332
     local ok, out = pcall(vim.fn.system, { "tmux", "show", "-g", "extended-keys" })
-    if ok and vim.trim(out):find(" on$") then
+    if ok and (vim.trim(out):find(" on$") or vim.trim(out):find(" always$")) then
       ok, out = pcall(vim.fn.system, { "tmux", "display-message", "-p", "#{client_termname}" })
       if ok then
         ret.terminal = vim.trim(out):gsub("^xterm%-", "")


### PR DESCRIPTION
## Description
Treat `tmux show -g extended-keys` returning `extended-keys always` the same as `extended-keys on` in image terminal detection.

Without this, snacks misses the tmux `client_termname` workaround and falls back to the terminal query / `TermResponse` path.

Verified locally with tmux 3.6a + Ghostty, where this fixed markdown picker freezes caused by image terminal detection.

## Related Issue(s)
Related to #2332

## Screenshots
N/A
