### PR TITLE
fix(image): reset hidden state when buffer becomes visible again

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -538,6 +538,9 @@ function M:update()
     self:hide()
     return
   end
+  if self.hidden then
+    self.hidden = false
+  end
   self.img:place(self)
 
   self:debug("update")


### PR DESCRIPTION
## Summary

When switching away from an image buffer, `placement:update()` calls `hide()` which sets `self.hidden = true`. When switching back, `update()` is triggered via `BufEnter`/`BufWinEnter` autocmds, but `self.hidden` is never reset to `false`. This causes `_render()` to produce empty extmarks, leaving the image invisible (stuck showing "identify loading…" or blank).

**Steps to reproduce:**
1. Open an image file via nvim-tree or fzf-lua — image displays correctly
2. Switch to another (non-image) buffer
3. Switch back to the image buffer — image fails to render

**Fix:** Reset `self.hidden = false` when `update()` detects visible windows (`#state.wins > 0`), so the image re-renders correctly on buffer re-entry.

## Test plan

- [x] Open image → switch away → switch back: image re-renders correctly
- [x] Multiple image buffers: switching between them works as expected
- [x] No regression: images still hide properly when no window is displaying them