### PR TITLE
fix(picker): change order of `cmd` for fd/fdfind and adjust health files

### DIFF
--- a/lua/snacks/health.lua
+++ b/lua/snacks/health.lua
@@ -93,7 +93,24 @@ function M.have_tool(tools)
         if vim.fn.executable(cmd) == 1 then
           local version = tool.version == false and "" or vim.fn.system(cmd .. " --version") or ""
           version = vim.trim(vim.split(version, "\n")[1])
-          if tool_version and tool_version > vim.version.parse(version) then
+          local parsed_version = nil
+          if tool.version ~= false then
+            parsed_version = vim.version.parse(version)
+            assert(
+              parsed_version,
+              "'"
+                .. cmd
+                .. "' returned invalid version string: `"
+                .. version
+                .. "`"
+                .. (
+                  cmd == "fd"
+                    and "\n You probably have `fdclone` installed instead of `fd-find` in a Debian derived distro via `apt`"
+                  or ""
+                )
+            )
+          end
+          if tool_version and parsed_version and tool_version > parsed_version then
             M.error("'" .. cmd .. "' `" .. version .. "` is too old, expected `" .. tool.version .. "`")
           elseif tool.version == false then
             M.ok("'" .. cmd .. "'")
@@ -103,6 +120,9 @@ function M.have_tool(tools)
             version_ok = true
           end
           found = true
+          if vim.deep_equal(cmds, { "fdfind", "fd" }) then
+            break
+          end
         end
       end
     end

--- a/lua/snacks/picker/core/_health.lua
+++ b/lua/snacks/picker/core/_health.lua
@@ -25,7 +25,7 @@ function M.health()
   end
 
   local have_fd, version_fd = Snacks.health.have_tool({
-    { cmd = { "fd", "fdfind" }, version = "v8.4" },
+    { cmd = { "fdfind", "fd" }, version = "v8.4" },
   })
   local have_find = have_fd
     or (jit.os:find("Windows") == nil and Snacks.health.have_tool({

--- a/lua/snacks/picker/source/files.lua
+++ b/lua/snacks/picker/source/files.lua
@@ -5,7 +5,7 @@ local uv = vim.uv or vim.loop
 ---@type {cmd:string[], args:string[], enabled?:boolean, available?:boolean|string}[]
 local commands = {
   {
-    cmd = { "fd", "fdfind" },
+    cmd = { "fdfind", "fd" },
     args = { "--type", "f", "--type", "l", "--color", "never", "-E", ".git" },
   },
   {


### PR DESCRIPTION
## Description
See https://github.com/LazyVim/LazyVim/issues/7093

This has come up multiple times now. I believe it's a small QOL for new users who don't know how to interpret things. Because in the current state, if a user has fdclone installed checkhealth will fail with `attempt to compare nil with a table`. If both fdclone and fd-find are installed, a user has to symlink fdfind to fd.

Feel free to disregard if deemed out of scope. Totally understandable.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
https://github.com/LazyVim/LazyVim/issues/7093
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

