### PR TITLE
fix(spawn): resolve executable path using vim.fn.exepath for Windows compatibility

### DIFF
--- a/lua/snacks/picker/source/proc.lua
+++ b/lua/snacks/picker/source/proc.lua
@@ -35,6 +35,11 @@ function M.proc(opts, ctx)
       end
     end
 
+    local cmd_path = vim.fn.exepath(opts.cmd)
+    if cmd_path == "" then
+        return Snacks.notify.error(opts.cmd .. " was not found.")
+    end
+
     if ctx.picker.opts.debug.proc then
       vim.schedule(function()
         ---@diagnostic disable-next-line: param-type-mismatch
@@ -58,9 +63,9 @@ function M.proc(opts, ctx)
 
     local handle ---@type uv.uv_process_t
     ---@diagnostic disable-next-line: missing-fields
-    handle = uv.spawn(opts.cmd, spawn_opts, function(code, _signal)
+    handle = uv.spawn(cmd_path, spawn_opts, function(code, _signal)
       if not aborted and code ~= 0 and opts.notify ~= false then
-        local full = { opts.cmd or "" }
+        local full = { cmd_path }
         vim.list_extend(full, opts.args or {})
         Snacks.notify.error(("Command failed:\n- cmd: `%s`"):format(table.concat(full, " ")))
       end
@@ -68,7 +73,7 @@ function M.proc(opts, ctx)
       self:resume()
     end)
     if not handle then
-      return Snacks.notify.error("Failed to spawn " .. opts.cmd)
+      return Snacks.notify.error("Failed to spawn " .. cmd_path)
     end
 
     local prev ---@type string?


### PR DESCRIPTION
## Description

This PR ensures external commands are resolved using vim.fn.exepath() before execution.

On Windows, uv.spawn fails to locate or execute batch files (.cmd, .bat) if only the filename is provided, as it exclusively searches for .exe files when the extension is omitted.
These .cmd files are the standard entry points used by tools installed via mason-tool-installer.

Using exepath ensures these files are correctly identified within the system PATH, preventing "file not found" errors and ensuring full compatibility with Mason-managed tools on Windows.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

