### PR TITLE
fix(image): check cursor is on the right line in at_cursor

### DIFF
--- a/lua/snacks/image/doc.lua
+++ b/lua/snacks/image/doc.lua
@@ -355,7 +355,7 @@ function M.at_cursor(cb)
       local range = img.range
       if range then
         if
-          (range[1] == range[3] and cursor[2] >= range[2] and cursor[2] <= range[4])
+          (range[1] == range[3] and range[1] == cursor[1] and cursor[2] >= range[2] and cursor[2] <= range[4])
           or (range[1] ~= range[3] and cursor[1] >= range[1] and cursor[1] <= range[3])
         then
           return cb(img.src, img.pos)


### PR DESCRIPTION
## Description

I noticed the floating images sometimes appeared even when my cursor was not on the image's line (see screenshot below). This is a trivial fix to ensure the cursor is on the same line as a single-line image treesitter node.

## Screenshots

Currently, the image is shown when my cursor is above it:
<img width="3110" height="1039" alt="image" src="https://github.com/user-attachments/assets/cc12674a-dd75-47d5-b893-80e4df02d27e" />
