### PR TITLE
refactor(indent): never attach scope if disabled in config

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -506,9 +506,11 @@ function M.enable()
   })
 
   -- Listen for scope changes
-  scopes = scopes or Snacks.scope.attach(M.on_scope, config.scope)
-  if not scopes.enabled then
-    scopes:enable()
+  if config.scope.enabled then
+    scopes = scopes or Snacks.scope.attach(M.on_scope, config.scope)
+    if not scopes.enabled then
+      scopes:enable()
+    end
   end
 
   local group = vim.api.nvim_create_augroup("snacks_indent", { clear = true })


### PR DESCRIPTION
This meaningfully improves my startup performance by never calling `snacks.scopes.attach` if the user has `config.scope.enabled` set to false. 

Before:
<img width="1551" height="163" alt="image" src="https://github.com/user-attachments/assets/0e140b09-bcc9-4d9c-bcfd-a3bdc606541d" />
After:
<img width="1555" height="144" alt="image" src="https://github.com/user-attachments/assets/502f0f87-589e-4d77-a127-a9691e85433b" />

This changes nothing if the user has scope drawing enabled.