### PR TITLE
feat(terminal): enable user to define on callbacks for all terminals

### DIFF
--- a/lua/snacks/terminal.lua
+++ b/lua/snacks/terminal.lua
@@ -28,7 +28,7 @@ local defaults = {
 ---@field auto_insert? boolean start insert mode when entering the terminal buffer
 ---@field auto_close? boolean close the terminal buffer when the process exits
 ---@field interactive? boolean shortcut for `start_insert`, `auto_close` and `auto_insert` (default: true)
----@field on? table<string, fun(term: snacks.win?)>? map from events to callbacks
+---@field on? table<vim.api.keyset.events, fun(term: snacks.win?)>? map from events to callbacks
 
 Snacks.config.style("terminal", {
   bo = {

--- a/lua/snacks/terminal.lua
+++ b/lua/snacks/terminal.lua
@@ -28,6 +28,7 @@ local defaults = {
 ---@field auto_insert? boolean start insert mode when entering the terminal buffer
 ---@field auto_close? boolean close the terminal buffer when the process exits
 ---@field interactive? boolean shortcut for `start_insert`, `auto_close` and `auto_insert` (default: true)
+---@field on? table<string, fun(term: snacks.win?)>? map from events to callbacks
 
 Snacks.config.style("terminal", {
   bo = {
@@ -156,6 +157,12 @@ function M.open(cmd, opts)
       terminal:close()
     end)
   end, { buf = true })
+
+  for event, callback in pairs(opts.on or {}) do
+    terminal:on(event, function()
+      callback(terminal)
+    end)
+  end
 
   terminal:show()
   vim.api.nvim_buf_call(terminal.buf, function()


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Adds a `opts.terminal.on` option, which is a table from events to callbacks. The callbacks will be registered on each terminal created by the plugin thanks to their `on` method.
I find myself wanting to apply a function on `TermClose` of each `snacks.nvim` terminal I create, which to my knowledge there is currently no easy way to do.