### PR TITLE
fix(picker.projects): add `--no-ignore` flag to `fd` arguments

### DIFF
--- a/lua/snacks/picker/source/recent.lua
+++ b/lua/snacks/picker/source/recent.lua
@@ -71,6 +71,7 @@ function M.projects(opts, ctx)
     "d",
     "--max-depth",
     tostring(opts.max_depth or 2),
+    "--no-ignore",
     "--follow",
     "--absolute-path",
   }


### PR DESCRIPTION
## Description

`fd` v9.0.0 introduced a breaking change whereby `.git` directories are not included even when `-H` is provided as an argument.

## Related Issue(s)

Fixes #2814 

## Screenshots

<img width="1219" height="126" alt="image" src="https://github.com/user-attachments/assets/067662ed-c9e5-46d3-8cbf-944a5e66a25b" />
