### PR TITLE
feat(image): added option to disable auto attaching to image buffers

### DIFF
--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -40,6 +40,7 @@ M.meta = {
 
 ---@class snacks.image.Config
 ---@field enabled? boolean enable image viewer
+---@field disable_auto_attach? boolean disable autocommands when opening an image file
 ---@field wo? vim.wo|{} options for windows showing the image
 ---@field bo? vim.bo|{} options for the image buffer
 ---@field formats? string[]
@@ -49,6 +50,7 @@ M.meta = {
 ---@field resolve? fun(file: string, src: string): string?
 ---@field convert? snacks.image.convert.Config
 local defaults = {
+  disable_auto_attach = false,
   formats = {
     "png",
     "jpg",
@@ -259,13 +261,15 @@ function M.setup(ev)
   })
 
   if M.config.formats and #M.config.formats > 0 then
-    vim.api.nvim_create_autocmd("BufReadCmd", {
-      pattern = "*." .. table.concat(M.config.formats, ",*."),
-      group = group,
-      callback = function(e)
-        M.buf.attach(e.buf)
-      end,
-    })
+    if not M.config.disable_auto_attach then
+      vim.api.nvim_create_autocmd("BufReadCmd", {
+        pattern = "*." .. table.concat(M.config.formats, ",*."),
+        group = group,
+        callback = function(e)
+          M.buf.attach(e.buf)
+        end,
+      })
+    end
     -- prevent altering the original image file
     vim.api.nvim_create_autocmd("BufWriteCmd", {
       pattern = "*." .. table.concat(M.config.formats, ",*."),

--- a/lua/snacks/init.lua
+++ b/lua/snacks/init.lua
@@ -192,7 +192,7 @@ function M.setup(opts)
     end,
   })
 
-  if M.config.image.enabled and #M.config.image.formats > 0 then
+  if M.config.image.enabled and #M.config.image.formats > 0 and not M.config.image.disable_auto_attach then
     vim.api.nvim_create_autocmd("BufReadCmd", {
       once = true,
       pattern = "*." .. table.concat(M.config.image.formats, ",*."),


### PR DESCRIPTION
## Description

Hello,

There are issues related to wezterm and image rendering. However for me, image rendering inside picker works perfectly well. Issues only happening when opening image directly. But image.nvim works perfect for opening images directly. 

In order to use them both, I wanted an option to disable only the automatic attaching to image files. This way, the picker works well and image files also works well (with image.nvim).

In this PR, the config name is more of a placeholder and the implementation is just a mere suggestion. **I am opening this PR but I intend this to be just a suggestion to create a middle ground.**

## Related Issue(s)

Issues related to terminal issues:
- #2165
- #1287
