### PR TITLE
fix(explorer): untracked file in untracked dir not getting updated

### DIFF
--- a/lua/snacks/explorer/git.lua
+++ b/lua/snacks/explorer/git.lua
@@ -120,6 +120,7 @@ function M._update(cwd, results)
   Tree:walk(node, function(n)
     n.status = nil
     n.ignored = nil
+    n.dir_status = nil
   end, { all = true })
 
   ---@param path string


### PR DESCRIPTION
## Problem
  Committing an untracked file inside a previously-untracked directory leaves the file rendered with `SnacksPickerGitStatusUntracked` in the explorer, even after `git status`
  reports it clean.

  ## Cause
  `M._update` in `lua/snacks/explorer/git.lua` clears `status` and `ignored` on every re-walk but not `dir_status`. Stale `??` on parent dir leaks to children via fallback in
  `lua/snacks/picker/source/explorer.lua:234-237`.

  ## Fix
  Also reset `n.dir_status` in the walk.

  ## Repro
  1. `mkdir foo && touch foo/bar.txt`
  2. Open snacks explorer — `foo/bar.txt` shows untracked.
  3. `git add foo/bar.txt && git commit -m wip`
  4. Explorer still shows `bar.txt` as untracked.