### PR TITLE
feat(explorer): add Y binding to yank relative path

### DIFF
--- a/doc/snacks.nvim-picker.txt
+++ b/doc/snacks.nvim-picker.txt
@@ -1273,6 +1273,7 @@ EXPLORER                                 *snacks.nvim-picker-sources-explorer*
             ["o"] = "explorer_open", -- open with system application
             ["P"] = "toggle_preview",
             ["y"] = { "explorer_yank", mode = { "n", "x" } },
+            ["Y"] = { "explorer_yank_relative", mode = { "n", "x" } },
             ["p"] = "explorer_paste",
             ["u"] = "explorer_update",
             ["<c-c>"] = "tcd",

--- a/docs/picker.md
+++ b/docs/picker.md
@@ -1048,6 +1048,7 @@ Neovim commands
         ["o"] = "explorer_open", -- open with system application
         ["P"] = "toggle_preview",
         ["y"] = { "explorer_yank", mode = { "n", "x" } },
+        ["Y"] = { "explorer_yank_relative", mode = { "n", "x" } },
         ["p"] = "explorer_paste",
         ["u"] = "explorer_update",
         ["<c-c>"] = "tcd",

--- a/lua/snacks/explorer/actions.lua
+++ b/lua/snacks/explorer/actions.lua
@@ -140,6 +140,25 @@ function M.actions.explorer_yank(picker)
   Snacks.notify.info("Yanked " .. #files .. " files")
 end
 
+function M.actions.explorer_yank_relative(picker)
+  local files = {} ---@type string[]
+  if vim.fn.mode():find("^[vV]") then
+    picker.list:select()
+  end
+  local cwd = picker:cwd()
+  for _, item in ipairs(picker:selected({ fallback = true })) do
+    local path = Snacks.picker.util.path(item)
+    if path and path:sub(1, #cwd + 1) == cwd .. "/" then
+      path = path:sub(#cwd + 2)
+    end
+    table.insert(files, path)
+  end
+  picker.list:set_selected() -- clear selection
+  local value = table.concat(files, "\n")
+  vim.fn.setreg(vim.v.register or "+", value, "l")
+  Snacks.notify.info("Yanked " .. #files .. " relative paths")
+end
+
 function M.actions.explorer_up(picker)
   picker:set_cwd(vim.fs.dirname(picker:cwd()))
   picker:find()

--- a/lua/snacks/picker/config/sources.lua
+++ b/lua/snacks/picker/config/sources.lua
@@ -88,6 +88,7 @@ M.explorer = {
         ["o"] = "explorer_open", -- open with system application
         ["P"] = "toggle_preview",
         ["y"] = { "explorer_yank", mode = { "n", "x" } },
+        ["Y"] = { "explorer_yank_relative", mode = { "n", "x" } },
         ["p"] = "explorer_paste",
         ["u"] = "explorer_update",
         ["<c-c>"] = "tcd",


### PR DESCRIPTION
## Description

Adds a Y keybinding in the explorer to copy the relative path of the selected file(s) to the register.

- y — yanks the absolute path (existing behavior)
- Y — yanks the relative path (new)

The relative path is computed against the explorer's current root (picker:cwd()). If a file lies outside the explorer root, the absolute path is preserved as a fallback.

Works with both single selection and visual/multi-select, matching the existing explorer_yank behavior.

## Related Issue(s)

None

## Screenshots

None

