### PR TITLE
fix(scope): respect `language.register()` in `TSScope:parser`

### DIFF
--- a/lua/snacks/scope.lua
+++ b/lua/snacks/scope.lua
@@ -385,8 +385,7 @@ end
 
 ---@param opts snacks.scope.Opts
 function TSScope:parser(opts)
-  local lang = vim.bo[opts.buf].filetype
-  local has_parser, parser = pcall(vim.treesitter.get_parser, opts.buf, lang, { error = false })
+  local has_parser, parser = pcall(vim.treesitter.get_parser, opts.buf, nil, { error = false })
   return has_parser and parser or nil
 end
 


### PR DESCRIPTION
## Description
`TSScope:parser` passes `vim.bo[opts.buf].filetype` directly as the lang argument to `vim.treesitter.get_parser`, bypassing any custom `vim.treesitter.language.register()` mappings. This change passes nil so `get_parser` does the filetype -> language resolution itself.
