### PR TITLE
fix(profiler): preserve nil holes when wrapping multi-return functions

### DIFF
--- a/lua/snacks/profiler/core.lua
+++ b/lua/snacks/profiler/core.lua
@@ -85,13 +85,13 @@ function M.trace(opts, caller, ...)
   ---@type snacks.profiler.Event
   local entry = { id = M.id, start = start, pid = pid, ref = caller, opts = opts }
   M.events[#M.events + 1] = entry
-  local ret = { pcall(opts.fn, ...) }
+  local ret = vim.F.pack_len(pcall(opts.fn, ...))
   M.pids[thread] = pid
   entry.stop = hrtime()
   if not ret[1] then
     error(ret[2])
   end
-  return select(2, unpack(ret))
+  return unpack(ret, 2, ret.n)
 end
 
 ---@param depth? number
@@ -152,18 +152,16 @@ function M.require(modname)
   if not M.running or package.loaded[modname] or M.skips[modname] then
     return M._require(modname)
   end
-  local ret = {
-    M.trace({
-      fname = "require",
-      name = "require:" .. modname,
-      require = modname,
-      fn = M._require,
-    }, M.caller(), modname),
-  }
+  local ret = vim.F.pack_len(M.trace({
+    fname = "require",
+    name = "require:" .. modname,
+    require = modname,
+    fn = M._require,
+  }, M.caller(), modname))
   if type(ret[1]) == "table" then
     M.attach_mod(modname, ret[1])
   end
-  return unpack(ret)
+  return vim.F.unpack_len(ret)
 end
 
 ---@param event any (string|array) Event(s) that will trigger the handler (`callback` or `command`).


### PR DESCRIPTION
## Problem

`Snacks.profiler.core.M.trace` wraps Lua functions to record start/stop
times:

```lua
local ret = { pcall(opts.fn, ...) }
...
return select(2, unpack(ret))
```

When the wrapped function returns multiple values that include a nil
hole, `#t` for non-sequence tables is undefined per Lua 5.1 spec —
"any border" is a valid result. LuaJIT's implementation may pick a
border at or before the first nil, causing `unpack(ret)` to truncate:

```lua
local function f() return nil, "value" end
local ret = { pcall(f) }            -- {true, nil, "value"}; borders: 1 and 3
return select(2, unpack(ret))       -- on LuaJIT may return just `nil`,
                                    -- truncating "value"
```

This breaks any wrapper around functions that follow the
`(err_or_nil, value)` return convention.

## Fix

Use `vim.F.pack_len` / `vim.F.unpack_len`, the canonical Neovim helpers
for preserving the explicit count of a vararg result. The same change
is applied to `M.require`.

## Related Issue(s)

None — discovered while profiling Neovim startup.