### PR TITLE
fix(gitbrowse): suppress location info on `__ignore__` error sentinel so it's properly ignored

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -122,7 +122,7 @@ local function system(cmd, err)
   local proc = vim.fn.system(cmd)
   if vim.v.shell_error ~= 0 then
     Snacks.notify.error({ err, proc }, { title = "Git Browse" })
-    error("__ignore__")
+    error("__ignore__", 0)
   end
   return vim.split(vim.trim(proc), "\n")
 end


### PR DESCRIPTION
## Description

Fix the `__ignore__` error sentinel in `gitbrowse` not being properly suppressed.

In `system()`, when a git command fails, a notification is shown and `error("__ignore__")` is raised so that `M.open()` can catch it via `pcall` and silently swallow it (since the user has already been notified).

However, by default `error()` prepends position information to the message (e.g. `...gitbrowse.lua:125: __ignore__`), so the equality check `err ~= "__ignore__"` on line 144 was always true and the error was re-raised, producing a noisy traceback on top of the notification.

Passing `0` as the second argument to `error()` disables the position info, so `err` is exactly `"__ignore__"` and the sentinel check works as intended.

## Related Issue(s)

N/A

## Screenshots

<img width="730" height="317" alt="Screenshot 2026-05-05 at 19 42 38" src="https://github.com/user-attachments/assets/0655b64d-3cef-461c-882d-e8144e053f12" />

