### PR TITLE
feat(toggle): add toggler for vim.lsp.document_color

### DIFF
--- a/docs/toggle.md
+++ b/docs/toggle.md
@@ -92,6 +92,13 @@ Snacks.toggle.diagnostics(opts)
 Snacks.toggle.dim()
 ```
 
+### `Snacks.toggle.document_color()`
+
+```lua
+---@param opts? snacks.toggle.Config
+Snacks.toggle.document_color(opts)
+```
+
 ### `Snacks.toggle.get()`
 
 ```lua

--- a/lua/snacks/toggle.lua
+++ b/lua/snacks/toggle.lua
@@ -217,6 +217,20 @@ function M.inlay_hints(opts)
 end
 
 ---@param opts? snacks.toggle.Config
+function M.document_color(opts)
+  return M.new({
+    id = "document_color",
+    name = "Document Color",
+    get = function()
+      return vim.lsp.document_color.is_enabled({ bufnr = 0 })
+    end,
+    set = function(state)
+      vim.lsp.document_color.enable(state, { bufnr = 0 })
+    end,
+  }, opts)
+end
+
+---@param opts? snacks.toggle.Config
 function M.diagnostics(opts)
   return M.new({
     id = "diagnostics",


### PR DESCRIPTION
## Description

This PR adds a toggler for `vim.lsp.document_color`, modeled after the implementation of `M.inlay_hints`. Similarly, no compatibility checks have been added, so please ensure proper support when invoking it.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

