### PR TITLE
fix(win): rebind buffer-local keymaps after set_buf

### DIFF
--- a/lua/snacks/picker/core/preview.lua
+++ b/lua/snacks/picker/core/preview.lua
@@ -280,7 +280,6 @@ function M:scratch()
   vim.bo[buf].filetype = "snacks_picker_preview"
   vim.o.eventignore = ei
   self.win:set_buf(buf)
-  self.win:map()
   self:minimal()
   return buf
 end

--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -968,6 +968,7 @@ function M:set_buf(buf)
   self.buf = buf
   vim.api.nvim_win_set_buf(self.win, buf)
   Snacks.util.wo(self.win, self.opts.wo)
+  self:map()
 end
 
 function M:map()


### PR DESCRIPTION
## Problem

When `win:set_buf(buf)` changes the buffer displayed in a `snacks.win` window, buffer-local keymaps are lost. This is because `map()` binds keymaps with `opts.buffer = self.buf`, making them specific to the original buffer. When the buffer is swapped, the new buffer has no keymaps.

### How to reproduce

1. Open a file that has LSP references (e.g. a function used in multiple places)
2. Press `gr` to open the LSP references picker
3. The picker shows three sub-windows: input, list, and preview
4. Press `<a-w>` to cycle focus to the preview window — **works**
5. Press `<a-w>` again to cycle back — **does not work**

### Why `<leader>/` (grep) is unaffected

The grep picker typically previews files that are **not** already loaded as buffers. In this case, the preview content is written directly into the scratch buffer via `set_lines()`, so `set_buf()` is never called and the original keymaps remain intact.

The LSP references picker, however, often previews files that **are** already loaded (since you're working in the same codebase). The previewer detects this and calls `preview:set_buf(ctx.item.buf)` to display the real buffer directly, which triggers the keymap loss.

### Root cause

`win.lua:M:set_buf()` updates `self.buf` and calls `nvim_win_set_buf`, but does **not** call `self:map()` to rebind keymaps to the new buffer:

```lua
function M:set_buf(buf)
  assert(self:valid(), "Window is not valid")
  self.buf = buf
  vim.api.nvim_win_set_buf(self.win, buf)
  Snacks.util.wo(self.win, self.opts.wo)
  -- keymaps are NOT rebound here
end
```

Notably, `picker/core/preview.lua:M:scratch()` already works around this by calling `self.win:map()` explicitly after `set_buf()`, suggesting the issue was partially known.

## Fix

- Add `self:map()` at the end of `win:set_buf()` so keymaps are always rebound when the buffer changes
- Remove the now-redundant `self.win:map()` call in `picker/core/preview.lua:scratch()`

### Diff

```diff
--- a/lua/snacks/win.lua
+++ b/lua/snacks/win.lua
@@ -968,6 +968,7 @@ function M:set_buf(buf)
   self.buf = buf
   vim.api.nvim_win_set_buf(self.win, buf)
   Snacks.util.wo(self.win, self.opts.wo)
+  self:map()
 end

--- a/lua/snacks/picker/core/preview.lua
+++ b/lua/snacks/picker/core/preview.lua
@@ -280,7 +280,6 @@ function M:scratch()
   vim.bo[buf].filetype = "snacks_picker_preview"
   vim.o.eventignore = ei
   self.win:set_buf(buf)
-  self.win:map()
   self:minimal()
   return buf
 end
```

Made with [Cursor](https://cursor.com)