### PR TITLE
fix(ui): determine `ext_multigrid` feature is enabled or not

### DIFF
--- a/lua/snacks/util/init.lua
+++ b/lua/snacks/util/init.lua
@@ -196,7 +196,7 @@ local transparent ---@type boolean?
 --- Check if the colorscheme is transparent.
 function M.is_transparent()
   if transparent == nil then
-    transparent = M.color("Normal", "bg") == nil
+    transparent = M.color("Normal", "bg") == nil and not M.is_multigrid_ui()
     vim.api.nvim_create_autocmd("ColorScheme", {
       group = vim.api.nvim_create_augroup("snacks_util_transparent", { clear = true }),
       callback = function()
@@ -205,6 +205,16 @@ function M.is_transparent()
     })
   end
   return transparent
+end
+
+--- Check if the ext_multigrid feature is enabled, better UI for neovide.
+function M.is_multigrid_ui()
+  for _, ui in ipairs(vim.api.nvim_list_uis()) do
+    if ui.ext_multigrid then
+      return true
+    end
+  end
+  return false
 end
 
 --- Redraw the range of lines in the window.


### PR DESCRIPTION
## Description

First of all, thank you for such amazing plugin.

There is a problem when I use neovide with input feature.

To fix this problem, I add function which determine the `ext_multigrid` feature is enabled or not, and than decide the winblend value should set to 0 or not.

## Screenshots

### Before

<img width="486" height="66" alt="Screenshot 2026-05-13 at 18 54 13" src="https://github.com/user-attachments/assets/2843da7c-8c78-4418-9cc8-9b87673dab9e" />

### After

<img width="477" height="56" alt="image" src="https://github.com/user-attachments/assets/5d78fe75-3af1-4954-927d-eb35ba1d3ab1" />
