### PR TITLE
fix(rename, words): use colon-notation for LSP client methods (closes #2839)

### DIFF
--- a/lua/snacks/rename.lua
+++ b/lua/snacks/rename.lua
@@ -94,8 +94,8 @@ function M.on_rename_file(from, to, rename)
 
   local clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)()
   for _, client in ipairs(clients) do
-    if client.supports_method("workspace/willRenameFiles") then
-      local resp = client.request_sync("workspace/willRenameFiles", changes, 1000, 0)
+    if client:supports_method("workspace/willRenameFiles") then
+      local resp = client:request_sync("workspace/willRenameFiles", changes, 1000, 0)
       if resp and resp.result ~= nil then
         vim.lsp.util.apply_workspace_edit(resp.result, client.offset_encoding)
       end
@@ -107,8 +107,8 @@ function M.on_rename_file(from, to, rename)
   end
 
   for _, client in ipairs(clients) do
-    if client.supports_method("workspace/didRenameFiles") then
-      client.notify("workspace/didRenameFiles", changes)
+    if client:supports_method("workspace/didRenameFiles") then
+      client:notify("workspace/didRenameFiles", changes)
     end
   end
 end

--- a/lua/snacks/words.lua
+++ b/lua/snacks/words.lua
@@ -113,7 +113,7 @@ function M.is_enabled(opts)
   else
     clients = (vim.lsp.get_clients or vim.lsp.get_active_clients)({ bufnr = buf })
     clients = vim.tbl_filter(function(client)
-      return client.supports_method("textDocument/documentHighlight", { bufnr = buf })
+      return client:supports_method("textDocument/documentHighlight", { bufnr = buf })
     end, clients)
   end
 


### PR DESCRIPTION
## Description

\`client.supports_method\`, \`client.request_sync\`, and \`client.notify\` are deprecated in Neovim 0.11+ and slated for removal in 0.13. Users see the warning in the wild — #2839 includes the stack traceback from \`rename.lua\`.

Convert the four call sites in \`snacks/rename.lua\` (lines 97, 98, 110, 111) and the one in \`snacks/words.lua\` (line 116) to colon-notation. This matches what \`snacks/picker/source/lsp/init.lua:94,204\` already does, so the change brings the two stragglers in line with the rest of the codebase.

## Related Issue(s)

- Fixes #2839

## Verification

Headless mock-client test confirms \`rename.on_rename_file\` dispatches \`supports_method\` / \`request_sync\` / \`supports_method\` / \`notify\` in order with no errors under colon-notation. \`words.lua\` change is the same syntax-equivalent transformation on a structurally identical call.