### PR TITLE
fix(image): apply tmux extended-keys workaround for `always` too

### DIFF
--- a/lua/snacks/image/terminal.lua
+++ b/lua/snacks/image/terminal.lua
@@ -256,7 +256,7 @@ function M._detect(cb)
     -- Workaround: Query tmux directly for the terminal name instead of sending escape sequences.
     -- See: https://github.com/folke/snacks.nvim/issues/2332
     local ok, out = pcall(vim.fn.system, { "tmux", "show", "-g", "extended-keys" })
-    if ok and vim.trim(out):find(" on$") then
+    if ok and (vim.trim(out):find(" on$") or vim.trim(out):find(" always$")) then
       ok, out = pcall(vim.fn.system, { "tmux", "display-message", "-p", "#{client_termname}" })
       if ok then
         ret.terminal = vim.trim(out):gsub("^xterm%-", "")


### PR DESCRIPTION
## Description

`tmux show -g extended-keys` returns `on`, `off`, or `always`. The existing workaround for terminal-response leaks only triggered when the value was `on`, so users with `set -s extended-keys always` still saw the `\033[>q` XTVERSION reply leak into the active window as literal text (e.g. `tty(0.46.2)`), often also tripping bracketed paste.

Match `always` in addition to `on` so the workaround engages for both.

## Related Issue(s)

Refs: #2332

## Screenshots

 N/A — terminal escape leak, no visual change.