### PR TITLE
fix(picker.lspreferences): preview for virtual files

### DIFF
--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -95,7 +95,7 @@ function M.file(ctx)
       vim.b[ctx.item.buf].snacks_picker_loaded = true
       vim.fn.bufload(ctx.item.buf)
     end
-  elseif ctx.item.file and ctx.item.file:find("^%w+://") then
+  elseif ctx.item.file and ctx.item.file:find("^[%w-]+://") then
     ctx.item.buf = vim.fn.bufadd(ctx.item.file)
     vim.b[ctx.item.buf].snacks_picker_loaded = true
     vim.fn.bufload(ctx.item.buf)


### PR DESCRIPTION
## Description

URIs for dynamic files provided by LSP server can contain non-alphanumer characters, such as hypen. 
This is the case for `roslyn` for example where the uri base is `roslyn-source-generated://` .

Due to this currently preview is lsp refernces picker is not being loaded 

Note that currently this is not working by default since it requires fetching document content from server directly.
Related upstream issue here https://github.com/neovim/neovim/issues/39526
Idea is to use autocmd on `BufReadCmd` to fetch it

## Related Issue(s)

Relates to: #677 

## Screenshots

<img width="2050" height="294" alt="image" src="https://github.com/user-attachments/assets/eef48bd1-6cfb-4f49-9180-c4d850662227" />

