### PR TITLE
fix(picker.select): floor list height to avoid fractional dim

### DIFF
--- a/lua/snacks/picker/select.lua
+++ b/lua/snacks/picker/select.lua
@@ -43,7 +43,7 @@ function M.select(items, opts, on_choice)
         -- Fit list height to number of items, up to 10
         for _, box in ipairs(layout.layout) do
           if box.win == "list" and not box.height then
-            box.height = math.max(math.min(#items, vim.o.lines * 0.8 - 10), 2)
+            box.height = math.max(math.min(#items, math.floor(vim.o.lines * 0.8 - 10)), 2)
           end
         end
       end,


### PR DESCRIPTION
## Description

`vim.o.lines * 0.8 - 10` in `lua/snacks/picker/select.lua:46` is fractional whenever `vim.o.lines` is not a multiple of 5 (e.g. 37 -> 19.6). When `#items` exceeds that bound, the surrounding `math.min` returns the fractional value and it lands on the `list` box height; `M:dim()`'s `size()` helper only floors when `s == 0` or `s < 1`, so the fractional flows through `nvim_win_set_config`:

```
E5108: Error executing lua .../snacks.nvim/lua/snacks/win.lua:810: Invalid 'height': Number is not integral
stack traceback:
        [C]: in function 'nvim_win_set_config'
        .../snacks.nvim/lua/snacks/win.lua:810: in function 'update'
        .../snacks.nvim/lua/snacks/layout.lua:288: in function 'update'
        .../snacks.nvim/lua/snacks/layout.lua:583: in function 'show'
        .../snacks.nvim/lua/snacks/picker/core/picker.lua:489: in function 'show'
        .../snacks.nvim/lua/snacks/picker/core/picker.lua:744: in function 'update'
```

Floor the bound at the source.

### Verification

`nvim --headless -u repro.lua --cmd "set lines=37 columns=120"` on Neovim 0.12.2 / Windows. Tap on `nvim_win_set_config` logs any non-integer dim before the call reaches Neovim:

| variant                                     | items | picker height | pre-fix              | post-fix |
| ------------------------------------------- | ----- | ------------- | -------------------- | -------- |
| default `select` preset                     | 50    | n/a           | ok                   | ok       |
| user 0.85 (the issue's repro)               | 100   | 0.85          | FAIL `height=21.6`   | ok       |
| user 0.6                                    | 5     | 0.6           | ok                   | ok       |
| user 0.95                                   | 1000  | 0.95          | FAIL `height=21.6`   | ok       |
| user 0.5, empty list                        | 0     | 0.5           | ok (no results)      | ok (no results) |

Pre-fix: 2 of 5 variants reproduce. Post-fix: 0 non-integer dim calls across all 5, no regression on the previously-passing ones. The `height=21.6` matches the issue's failure (`vim.o.lines=37, cmdheight=1 -> inner area 36, 36 * 0.6 = 21.6` after border accounting).

## Related Issue(s)

- Fixes #2539

## Screenshots

N/A