### PR TITLE
fix(picker,explorer): resolve bare executable names on Windows before uv.spawn

### DIFF
--- a/lua/snacks/explorer/git.lua
+++ b/lua/snacks/explorer/git.lua
@@ -1,4 +1,6 @@
 ---@diagnostic disable: missing-fields
+local Spawn = require("snacks.util.spawn")
+
 local M = {}
 
 ---@class snacks.explorer.git.Status
@@ -55,7 +57,7 @@ function M.update(cwd, opts)
   local output = ""
   local stdout = assert(uv.new_pipe())
   local handle ---@type uv.uv_process_t
-  handle = uv.spawn("git", {
+  handle = uv.spawn(Spawn.resolve_cmd("git"), {
     stdio = { nil, stdout, nil },
     cwd = root,
     hide = true,

--- a/lua/snacks/picker/source/proc.lua
+++ b/lua/snacks/picker/source/proc.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: await-in-sync
 local Async = require("snacks.picker.util.async")
+local Spawn = require("snacks.util.spawn")
 
 local M = {}
 
@@ -58,7 +59,7 @@ function M.proc(opts, ctx)
 
     local handle ---@type uv.uv_process_t
     ---@diagnostic disable-next-line: missing-fields
-    handle = uv.spawn(opts.cmd, spawn_opts, function(code, _signal)
+    handle = uv.spawn(Spawn.resolve_cmd(opts.cmd), spawn_opts, function(code, _signal)
       if not aborted and code ~= 0 and opts.notify ~= false then
         local full = { opts.cmd or "" }
         vim.list_extend(full, opts.args or {})

--- a/lua/snacks/util/spawn.lua
+++ b/lua/snacks/util/spawn.lua
@@ -5,6 +5,34 @@ local M = {}
 
 local uv = vim.uv or vim.loop
 
+local is_windows = (uv.os_uname().sysname or ""):lower():find("windows") ~= nil
+
+--- Resolve a bare executable name to an absolute path on Windows.
+--- libuv's `spawn` does not search `PATH` for bare names on Windows the way
+--- it does on POSIX, so a command like `rg` may return ENOENT even when
+--- `vim.fn.exepath("rg")` resolves it (e.g. through a scoop shim).
+--- Returns the input unchanged on non-Windows systems, when given a path
+--- (anything containing `/` or `\`), or when resolution fails.
+---@param cmd string
+---@return string
+function M.resolve_cmd(cmd)
+  if not is_windows or type(cmd) ~= "string" or cmd == "" then
+    return cmd
+  end
+  if cmd:find("[/\\]") then
+    return cmd
+  end
+  local resolved = vim.fn.exepath(cmd .. ".exe")
+  if resolved ~= "" then
+    return resolved
+  end
+  resolved = vim.fn.exepath(cmd)
+  if resolved ~= "" then
+    return resolved
+  end
+  return cmd
+end
+
 ---@class snacks.spawn.Config: uv.spawn.options,{}
 ---@field cmd string
 ---@field args? (string|number)[]
@@ -149,7 +177,7 @@ function Proc:run()
     hide = true,
     args = vim.tbl_map(tostring, self.opts.args or {}),
   })
-  self.handle = uv.spawn(self.opts.cmd, opts, function(code, signal)
+  self.handle = uv.spawn(M.resolve_cmd(self.opts.cmd), opts, function(code, signal)
     self.code = code
     self.signal = signal
     self:on_exit()

--- a/tests/spawn_spec.lua
+++ b/tests/spawn_spec.lua
@@ -1,0 +1,32 @@
+---@module 'luassert'
+
+describe("snacks.spawn.resolve_cmd", function()
+  local Spawn = require("snacks.util.spawn")
+
+  local is_windows = (vim.uv or vim.loop).os_uname().sysname:lower():find("windows") ~= nil
+
+  it("returns non-string input unchanged", function()
+    assert.are.same(nil, Spawn.resolve_cmd(nil))
+  end)
+
+  it("returns empty string unchanged", function()
+    assert.are.same("", Spawn.resolve_cmd(""))
+  end)
+
+  it("returns an absolute POSIX path unchanged", function()
+    assert.are.same("/usr/bin/rg", Spawn.resolve_cmd("/usr/bin/rg"))
+  end)
+
+  it("returns a Windows-style backslash path unchanged", function()
+    assert.are.same([[C:\Tools\rg.exe]], Spawn.resolve_cmd([[C:\Tools\rg.exe]]))
+  end)
+
+  if not is_windows then
+    it("returns a bare command unchanged on non-Windows", function()
+      -- On POSIX, libuv's spawn searches PATH for bare names, so resolve_cmd
+      -- is a no-op for bare commands like "rg" or "git".
+      assert.are.same("rg", Spawn.resolve_cmd("rg"))
+      assert.are.same("git", Spawn.resolve_cmd("git"))
+    end)
+  end
+end)


### PR DESCRIPTION
## Description

On native Windows Neovim, `Snacks.picker.files()` / `Snacks.picker.grep()` can fail with `Failed to spawn rg` / `Failed to spawn fd` even when `:checkhealth snacks` reports both as available and `:lua print(vim.fn.exepath("rg"))` resolves to a working shim (e.g. `C:\Users\user\scoop\shims\rg.EXE`). Same shape applies to `Snacks.explorer`'s git status poller calling bare `git`, and to anything else that goes through `Snacks.spawn`.

The root cause is that libuv's `spawn` does not search `PATH` for bare command names on Windows the way it does on POSIX. The reporter (#2872) traced the failing call to `uv.spawn(opts.cmd, ...)` in `lua/snacks/picker/source/proc.lua`, confirmed the picker recovers when the executable is resolved through `vim.fn.exepath()` first, and noted that the same pattern probably affects every `uv.spawn` call site.

There are three of those today:

- `lua/snacks/util/spawn.lua` — the `Proc:run` helper, used by `Snacks.image.convert`, `Snacks.gh.api`, and anything else that calls `Snacks.spawn`
- `lua/snacks/picker/source/proc.lua` — `picker.files`, `picker.grep`, and every other process-backed source
- `lua/snacks/explorer/git.lua` — the git status poller behind the explorer's status column

This PR adds a small `Snacks.spawn.resolve_cmd(cmd)` helper and wraps the command at each of those sites. The helper:

- Returns the input unchanged on non-Windows systems (libuv's POSIX path search already works there)
- Returns the input unchanged if the value already contains `/` or `\` (it's a path, no resolution needed)
- On Windows, tries `vim.fn.exepath(cmd .. ".exe")` first, then `vim.fn.exepath(cmd)`, returning the input unchanged if neither resolves

No behavior change on Linux/macOS. On Windows it does exactly what the issue's snippet did, just in one shared helper instead of inline at each site.

## Testing

- `stylua --check` clean on the three modified files plus the new spec
- Luac syntax check clean
- New `tests/spawn_spec.lua` covers the platform guard, defensive inputs (nil, empty, POSIX path, Windows-style backslash path), and the no-op on non-Windows for bare names. The Windows-specific resolution path is exercised by the reporter's scoop setup in #2872; I don't have a Windows CI runner here, so the new spec only locks the contract that exists on the platforms CI does run on
- No new dependencies; only `vim.fn.exepath` and `uv.os_uname` are used, both available in every supported Neovim

Closes #2872
