### PR TITLE
fix(picker.projects): pass --no-ignore-vcs so fd 9.0.0 surfaces .git

### DIFF
--- a/lua/snacks/picker/source/recent.lua
+++ b/lua/snacks/picker/source/recent.lua
@@ -63,6 +63,7 @@ M.recent = M.files
 function M.projects(opts, ctx)
   local args = {
     "-H",
+    "--no-ignore-vcs", -- fd 9.0.0 hides .git/ with -H, this restores it (sharkdp/fd#1396)
     "-t",
     "f",
     "-t",


### PR DESCRIPTION
## Description

fd 9.0.0 ([sharkdp/fd#1396](https://github.com/sharkdp/fd/pull/1396)) made `.git/` ignored by default even with `--hidden`, breaking `Snacks.picker.projects()` discovery on every system where that build is installed. Reverted in fd 10.0.0 but Ubuntu 24.04 LTS still ships fd 9.0.0 in its archive, so users on that distro can't find any `.git` projects.

The fd changelog calls out `--no-ignore-vcs` as the targeted override. Adding it to the args list in `lua/snacks/picker/source/recent.lua:M.projects` is a no-op on fd 8.x and fd 10+ for the existing `-H -g {.git,...}` use.

### Verification

`cargo install --version 9.0.0 fd-find` on Windows, two empty git projects under `/tmp/fd-test`:

| | output |
| --- | --- |
| pre-fix (`fd -H -t f -t s -t d --max-depth 2 --follow --absolute-path -g "{.git,_darcs,.hg,.bzr,.svn,package.json,Makefile}" /tmp/fd-test`) | (empty) — reproduces |
| post-fix (`+ --no-ignore-vcs`) | `proj1/.git/` and `proj2/.git/` — fixed |

Side-effect check on a `node_modules` + `.gitignore` project:

| | max_depth=2 (default) | max_depth=3 |
| --- | --- | --- |
| pre-fix | top-level `package.json` only | same |
| post-fix | top-level `package.json` + `.git/` | + the gitignored `node_modules/lodash/package.json` |

No regression at the default depth. At deeper custom depths the flag's documented behavior (descending into gitignored dirs) becomes observable, which is what someone passing `max_depth=4+` for a project discovery use is reasonably asking for.

## Related Issue(s)

- Fixes #2814

## Screenshots

N/A