### PR TITLE
feat(image): add support for d2 diagrams in markdown

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -117,6 +117,15 @@ local commands = {
       end
     end,
   },
+  d2 = {
+    cmd = {
+      cmd = "d2",
+      args = Snacks.image.config.convert.d2,
+    },
+    file = function(convert, ctx)
+      return convert:tmpfile(vim.o.background .. ".png")
+    end,
+  },
   mmd = {
     cmd = {
       cmd = "mmdc",

--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -121,8 +121,20 @@ local defaults = {
   ---@class snacks.image.convert.Config
   convert = {
     notify = false, -- show a notification on error
+    ---@class snacks.image.d2.Opts
+    d2_opts = {
+      layout = "dagre", -- default layout engine
+      theme = nil
+    },
     ---@type snacks.image.args
-    mermaid = function()
+    d2 = function ()
+      local opts = M.config.convert.d2_opts
+      local theme = opts.theme or (vim.o.background == "light" and "0" or "200")
+      local layout = M.config.convert.d2_opts.layout
+      return { "{src}", "{file}", "--layout", layout, "--theme", theme, "--scale", "{scale}" }
+    end,
+    ---@type snacks.image.args
+    mermaid = function ()
       local theme = vim.o.background == "light" and "neutral" or "dark"
       return { "-i", "{src}", "-o", "{file}", "-b", "transparent", "-t", theme, "-s", "{scale}" }
     end,

--- a/queries/markdown/images.scm
+++ b/queries/markdown/images.scm
@@ -15,3 +15,11 @@
   (#set! injection.language "mermaid")
   (#set! image.ext "chart.mmd")
 ) @image
+
+(fenced_code_block
+  (info_string (language) @lang)
+  (#eq? @lang "d2")
+  (code_fence_content) @image.content
+  (#set! injection.language "d2")
+  (#set! image.ext "chart.d2")
+) @image

--- a/tests/image/test-d2.md
+++ b/tests/image/test-d2.md
@@ -1,0 +1,10 @@
+```d2
+good chips: {
+  doritos
+  ruffles
+}
+bad chips.lays
+bad chips.pringles
+
+chocolate.chip.cookies
+```


### PR DESCRIPTION
## Description

I've recently had troubles with installing dependencies for mmdc, so I thought that I would give https://d2lang.com a try 

## Related Issue(s)

It was already requested: https://github.com/folke/snacks.nvim/discussions/1446

## Screenshots
<img width="1261" height="1114" alt="image" src="https://github.com/user-attachments/assets/c0ae15b5-ea8e-4bd6-bf29-e9c4b247123c" />
