### PR TITLE
fix(picker.util): require trailing slash when matching git root in truncpath

### DIFF
--- a/lua/snacks/picker/util/init.lua
+++ b/lua/snacks/picker/util/init.lua
@@ -29,7 +29,7 @@ function M.truncpath(path, len, opts)
     path = path:sub(#cwd + 2)
   else
     local root = Snacks.git.get_root(path)
-    if root and root ~= "" and path:find(root, 1, true) == 1 then
+    if root and root ~= "" and path:find(root .. "/", 1, true) == 1 then
       local tail = vim.fn.fnamemodify(root, ":t")
       path = "⋮" .. tail .. "/" .. path:sub(#root + 2)
     elseif path:find(home, 1, true) == 1 then


### PR DESCRIPTION
## Description

When Snacks.git.get_root() returns "." (e.g. when inside a git repo using a relative path), the truncpath function's root-matching logic used `path:find(root, 1, true) == 1`. This bare match on "." would also match the leading dot of dotfiles like .stylua.toml, causing the root-replacement logic to consume the dot and produce corrupted paths, e.g. .stylua.toml → ./tylua.toml.

The character after the dot was consumed as part of the root match by `path:sub(#root + 2)`.

Changed the match from `path:find(root, 1, true)` to `path:find(root .. "/", 1, true)`, requiring a trailing / after the root. This ensures the root is only matched as a directory prefix, so dotfiles and other paths starting with . are left intact. The slash after "." is assumed and removed anyways (the +2 part), so it's semantically the same.