### PR TITLE
fix(dashboard): guard cursor update when window shows another buffer

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -718,6 +718,11 @@ function D:update()
   -- cursor movement
   local last = { 1, 0 }
   local function update_cursor()
+    -- the dashboard window may now show a different buffer (e.g. it was replaced
+    -- with `:enew` while another split still displays the dashboard)
+    if not vim.api.nvim_win_is_valid(self.win) or vim.api.nvim_win_get_buf(self.win) ~= self.buf then
+      return
+    end
     local item = self:find(vim.api.nvim_win_get_cursor(self.win), last)
     -- can happen for panes without actionable items
     item = item or vim.tbl_filter(function(it)


### PR DESCRIPTION
## Description

When the dashboard is open and its window's buffer is replaced (e.g. `:enew` or `:e foo`) while another split still shows the dashboard buffer, the dashboard's `CursorMoved` autocmd keeps running `update_cursor` against `self.win`. That window now displays a shorter buffer, so `nvim_win_set_cursor(self.win, { <dashboard row>, ... })` raises:

```
.../snacks.nvim/lua/snacks/dashboard.lua:731: Invalid cursor line: out of range
stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        .../snacks.nvim/lua/snacks/dashboard.lua:731: in function <.../dashboard.lua:720>
```

`update_cursor` now returns early when `self.win` is no longer valid or no longer shows `self.buf`, so the cursor is only positioned while the window actually displays the dashboard.

## Related Issue(s)

Fixes #2869

## Screenshots

N/A — terminal error with no visual component.

### Verification

Reproduced headless with the issue's steps (open dashboard, `:split`, switch back, `:enew`, switch to the split, fire CursorMoved): the `Invalid cursor line: out of range` error fires before the change and is gone after. Confirmed normal cursor snapping on an intact dashboard is unaffected (cursor still lands on the first actionable item).
