### PR TITLE
fix(scroll): memory leak in window state map

### DIFF
--- a/lua/snacks/scroll.lua
+++ b/lua/snacks/scroll.lua
@@ -201,6 +201,17 @@ function M.enable()
     end),
   })
 
+  -- clean up state when a window is closed
+  vim.api.nvim_create_autocmd("WinClosed", {
+    group = group,
+    callback = function(ev)
+      local win = tonumber(ev.match)
+      if win then
+        State.reset(win)
+      end
+    end,
+  })
+
   -- clear scroll state when leaving the cmdline after a search with incsearch
   vim.api.nvim_create_autocmd({ "CmdlineLeave" }, {
     group = group,


### PR DESCRIPTION
The State map is never cleared when a Window is closed, so it's size increases continuously.

## Description

This fixes a memory leak in the scroll.lua module

