### PR TITLE
fix(image.inline): keep placements when find_visible returns no images

### DIFF
--- a/lua/snacks/image/inline.lua
+++ b/lua/snacks/image/inline.lua
@@ -93,6 +93,13 @@ function M:update()
     return conceal
   end or conceal
   Snacks.image.doc.find_visible(self.buf, function(imgs)
+    -- `find_visible` is treesitter-backed and can return no images while the
+    -- parser reparses a rapidly-changing buffer, even when an image is still
+    -- present. Treating that as "all gone" closes and recreates placements on
+    -- the next parse, which flickers. Keep placements until it reports images.
+    if #imgs == 0 then
+      return
+    end
     local visible = self:visible()
     local stats = { new = 0, del = 0, update = 0 }
     for _, i in ipairs(imgs) do


### PR DESCRIPTION
## Description

Inline images flicker on rapidly-appending buffers (e.g. streaming chat output into a markdown buffer with an inline image).

`Snacks.image.doc.find_visible` is treesitter-backed and intermittently returns **zero** images while the parser is mid-reparse during streaming, even though the image is still in the buffer.

Treat an empty result as inconclusive: keep existing placements, reconcile only when `find_visible` reports images.

Tradeoff: N images → 0 defers closing the last placement until a later non-empty `find_visible`.

One-line guard; no behavior change for non-streaming buffers.
