### PR TITLE
fix(picker): git status without locks

### DIFF
--- a/lua/snacks/picker/source/git.lua
+++ b/lua/snacks/picker/source/git.lua
@@ -219,7 +219,7 @@ end
 ---@param opts snacks.picker.git.status.Config
 ---@type snacks.picker.finder
 function M.status(opts, ctx)
-  local args = M.git("status", "-uall", "--porcelain=v1", "-z", { args = { "--no-pager" } }, opts)
+  local args = M.git("status", "-uall", "--porcelain=v1", "-z", { args = { "--no-pager", "--no-optional-locks" } }, opts)
   if opts.ignored then
     table.insert(args, "--ignored=matching")
   end


### PR DESCRIPTION
## Description

`Snacks.picker.git_status()` would close after a split second with a [Flog](https://github.com/rbong/vim-flog/) or [DiffView](https://github.com/sindrets/diffview.nvim) window open