### PR TITLE
fix(image): clear conceal_lines when hiding placements

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -376,6 +376,7 @@ function M:_render(extmarks)
     if self.hidden then
       e.virt_text = nil
       e.conceal = nil
+      e.conceal_lines = nil
       if e.virt_lines then
         e.virt_lines = vim.tbl_map(function(l)
           return { { "" } }


### PR DESCRIPTION
## Description

- When an inline placement is hidden (e.g. cursor inside a concealed math block), `_render` cleared `conceal` but left `conceal_lines` set.
- Tall math environments use `conceal_lines` for rows below the image height, so those lines stayed hidden while editing.
- Clear `conceal_lines` alongside `conceal` when `hidden` is true.

## Related Issue(s)

- Fixes #2569
