### PR TITLE
fix(bufdelete.all): improved Cancel behavior on bufdelete.all() (closes #2912)

### DIFF
--- a/lua/snacks/bufdelete.lua
+++ b/lua/snacks/bufdelete.lua
@@ -31,7 +31,10 @@ function M.delete(opts)
   if type(opts.filter) == "function" then
     for _, b in ipairs(vim.tbl_filter(opts.filter, vim.api.nvim_list_bufs())) do
       if vim.bo[b].buflisted then
-        M.delete(vim.tbl_extend("force", {}, opts, { buf = b, filter = false }))
+        local res = M.delete(vim.tbl_extend("force", {}, opts, { buf = b, filter = false }))
+        if res == -1 then
+          return
+        end
       end
     end
     return
@@ -54,7 +57,7 @@ function M.delete(opts)
   if vim.bo[buf].modified and not opts.force then
     local ok, choice = pcall(vim.fn.confirm, ("Save changes to %q?"):format(vim.fn.bufname(buf)), "&Yes\n&No\n&Cancel")
     if not ok or choice == 0 or choice == 3 then -- 0 for <Esc>/<C-c> and 3 for Cancel
-      return
+      return -1
     elseif choice == 1 then -- Yes
       vim.api.nvim_buf_call(buf, vim.cmd.write)
     end


### PR DESCRIPTION
## Description
Fixes Cancel behavior of Snacks.bufdelete.all()
Cancel now returns -1 and it is checked for when .all() is called and stops the loop

## Related Issue(s)
  - Fixes #2912 

## Screenshots


https://github.com/user-attachments/assets/90c296d9-9fa6-4849-a643-9bcaf6d569dc


