### PR TITLE
fix(picker): floor list height to prevent non-integral height error in vim.ui.select

### DIFF
--- a/lua/snacks/picker/select.lua
+++ b/lua/snacks/picker/select.lua
@@ -43,7 +43,7 @@ function M.select(items, opts, on_choice)
         -- Fit list height to number of items, up to 10
         for _, box in ipairs(layout.layout) do
           if box.win == "list" and not box.height then
-            box.height = math.max(math.min(#items, vim.o.lines * 0.8 - 10), 2)
+            box.height = math.max(math.min(#items, math.floor(vim.o.lines * 0.8 - 10)), 2)
           end
         end
       end,


### PR DESCRIPTION
## Description

`Snacks.picker.select` computes the list height as `vim.o.lines * 0.8 - 10` without flooring. When `vim.o.lines` isn't a multiple of 5, the result is fractional and gets passed straight to `nvim_win_set_config`, which requires an integral height for floating windows. Any `vim.ui.select` call with enough items to hit the cap triggered E5108, blocking the picker from rendering.

This commit wraps the cap in `math.floor` to guarantee an integer.

## Related Issue(s)
I hit this bug in my config but when filing an issue, I found a preexisting one: https://github.com/folke/snacks.nvim/issues/2539.

This fix should solve it.

## Screenshots
N/A