### PR TITLE
fix(dashboard): guard augroup deletion on buffer wipeout

### DIFF
--- a/lua/snacks/dashboard.lua
+++ b/lua/snacks/dashboard.lua
@@ -259,7 +259,10 @@ function D:init()
     buffer = self.buf,
     callback = function()
       self.fire("Closed")
-      vim.api.nvim_del_augroup_by_id(self.augroup)
+      if self.augroup then
+        pcall(vim.api.nvim_del_augroup_by_id, self.augroup)
+        self.augroup = nil
+      end
     end,
   })
   vim.api.nvim_create_autocmd("WinEnter", {


### PR DESCRIPTION
## Description

All dashboard instances share a single fixed augroup name (`"snacks_dashboard"`), so they resolve to the **same** augroup id. Each dashboard buffer, however, installs its own buffer-local `BufWipeout`/`BufDelete` autocmd that **unconditionally** calls `nvim_del_augroup_by_id(self.augroup)`:

```lua
vim.api.nvim_create_autocmd({ "BufWipeout", "BufDelete" }, {
  buffer = self.buf,
  callback = function()
    self.fire("Closed")
    vim.api.nvim_del_augroup_by_id(self.augroup)
  end,
})
```

When more than one dashboard buffer is alive at once, the first buffer wiped deletes the shared augroup, and the second buffer wiped tries to delete the same (now-deleted) id, throwing:

```
dashboard.lua:262: Vim:E367: No such group: "--Deleted--"
```

This happens whenever the dashboard is opened more than once in a session (e.g. startup dashboard + reopening it, or configs that reopen the dashboard when the last buffer is closed) and the buffers are later wiped, such as when opening a file from a picker.

This PR wraps the deletion in `pcall` and clears `self.augroup` afterwards, matching the pattern already used elsewhere in the codebase (`win.lua`, `image/placement.lua`, `explorer/init.lua`).

### Reproduction

```lua
local d1 = Snacks.dashboard.open()
local d2 = Snacks.dashboard.open() -- shares d1's augroup id
vim.api.nvim_buf_delete(d1.buf, { force = true }) -- deletes the shared augroup
vim.api.nvim_buf_delete(d2.buf, { force = true }) -- E367 before this fix
```

Before: the second delete throws `E367`. After: both deletes succeed.

## Related Issue(s)

- Fixes #2724