### PR TITLE
fix(image): leaked progress timer and hidden-latched placements broke reopening images

### DIFF
--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -149,19 +149,28 @@ function M:progress()
   vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, {})
   vim.bo[self.buf].modifiable = false
   local timer = assert(uv.new_timer())
+  local eid ---@type number?
   timer:start(
     0,
     80,
     vim.schedule_wrap(function()
-      if self:ready() or self.img:failed() or not vim.api.nvim_buf_is_valid(self.buf) then
+      local valid = vim.api.nvim_buf_is_valid(self.buf)
+      -- also stop when the placement is closed: `self:ready()` can never
+      -- become true for a closed placement, and the buffer may stay valid
+      -- (and be reused for the same file) long after the placement is gone
+      if self.closed or self:ready() or self.img:failed() or not valid then
         timer:stop()
         if not timer:is_closing() then
           timer:close()
         end
+        -- remove the spinner instead of leaving it behind
+        if eid and valid then
+          vim.api.nvim_buf_del_extmark(self.buf, ns, eid)
+        end
         return
       end
       vim.api.nvim_buf_clear_namespace(self.buf, ns, 0, -1)
-      vim.api.nvim_buf_set_extmark(self.buf, ns, 0, 0, {
+      eid = vim.api.nvim_buf_set_extmark(self.buf, ns, 0, 0, {
         virt_text = {
           { Snacks.util.spinner(), "SnacksImageSpinner" },
           { " " },

--- a/lua/snacks/image/placement.lua
+++ b/lua/snacks/image/placement.lua
@@ -547,6 +547,12 @@ function M:update()
     self:hide()
     return
   end
+  -- the buffer is visible again, so un-hide. Inline placements are
+  -- hidden/shown explicitly by `snacks.image.inline`, so leave those alone.
+  if self.hidden and not self.opts.inline then
+    self.hidden = false
+    state.hidden = false
+  end
   self.img:place(self)
 
   self:debug("update")


### PR DESCRIPTION
> **Note on authorship:** I am Claude, an AI assistant (Claude Code), and I investigated these bugs and wrote this PR on behalf of @ctbaum, who reviewed it and is submitting it from his account. Everything below (analysis, reproductions, and fixes) was verified by actually running the repro scripts against both the unpatched and patched code, plus interactive testing in a real terminal.

This PR fixes two related bugs in `snacks.image` placements. Together they produce the user-visible failure "an image file displays fine the first time, but shows a stuck `identify loading …` spinner, or nothing at all, when opened again". Each bug has a deterministic, self-contained reproduction below.

Both reproductions run with `nvim --clean --headless`, no plugins, no user config, and with terminal detection stubbed. So neither bug is related to the terminal emulator (kitty/wezterm/ghostty), to any multiplexer, or to graphics protocol handling; both are pure Lua timer/extmark/state logic. They were originally observed interactively on macOS in Ghostty and reproduce identically headless.

## Bug 1: leaked progress spinner timer

### Symptom

Close an image buffer while its conversion is still running (for example `:bd!` right after opening a large PNG), then reopen the same file. The buffer permanently shows the animated `identify loading …` spinner and the image never appears, even though the conversion finished long ago. Only restarting Neovim recovers.

### Root cause

`Placement:progress()` starts a repeating 80 ms `uv` timer that, on every tick:

1. clears **all** `snacks.image` extmarks in the buffer (`nvim_buf_clear_namespace`), and
2. draws the `<step> loading …` spinner extmark.

Its stop condition is:

```lua
if self:ready() or self.img:failed() or not vim.api.nvim_buf_is_valid(self.buf) then
```

`Placement:ready()` is `not self.closed and buf_valid and self.img:ready()`. Once a placement is **closed**, `self:ready()` is permanently false. If a placement is closed while its image conversion is still in flight, none of the three stop conditions can ever become true:

- `self:ready()` is false forever (placement closed),
- `self.img:failed()` stays false (the conversion succeeds),
- the buffer stays **valid** after `:bd` (it is only unloaded, not wiped).

The timer therefore leaks and runs forever. Because Neovim reuses the same buffer when the same file is edited again, the leaked timer keeps wiping the new placement's extmarks every 80 ms and redrawing the spinner. The reopened image converts, is sent, and is placed correctly (`img:ready() == true`, `sent == true`, one active placement), but its placeholder grid is deleted 80 ms after every render, so the user only ever sees `identify loading …`.

Closing a not-yet-ready placement is easy to hit in practice: a large image, or a small one whose `identify` is queued behind other conversions (all conversions share the `MAX_PROCS = 3` queue in `convert.lua`, so documents with many mermaid/LaTeX conversions delay everything else).

There is a smaller secondary issue in the same function: when the timer stops normally, the last drawn spinner extmark is not removed. It is untracked (`self.eids` never contains it), so `Placement:_render()` does not delete it either, and stale `… loading …` virtual text can survive next to a successfully rendered image.

### Fix

- Add `self.closed` to the timer's stop condition.
- Track the spinner extmark id and delete it when the timer stops, instead of leaving the last drawn spinner behind.

### Reproduction

<details>
<summary><code>spinner_leak_repro.lua</code> (click to expand)</summary>

```lua
-- Run:  nvim --clean --headless -l spinner_leak_repro.lua <snacks.nvim path> <big png path>
-- Create the test image first (large so the conversion takes a few seconds):
--   magick -size 6000x6000 plasma:fractal big.png

local snacks_path, png = arg[1], arg[2]
assert(snacks_path and png, "usage: nvim --clean --headless -l spinner_leak_repro.lua <snacks.nvim> <png>")

vim.opt.runtimepath:prepend(snacks_path)
require("snacks").setup({ image = { enabled = true } })

-- Stub terminal detection/output: pretend we are on kitty with placeholder
-- support so the image pipeline runs; nothing is written to the real tty.
local terminal = require("snacks.image.terminal")
terminal._terminal = { terminal = "kitty", version = "0.0-repro" }
local env = terminal.env()
env.supported, env.placeholders, env.remote = true, true, false
terminal.write = function() end

local ns = require("snacks.image.placement").ns

local function spinner_extmarks(buf)
  local found = {}
  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })) do
    local vt = m[4].virt_text
    if vt then
      for _, chunk in ipairs(vt) do
        if chunk[1]:find("loading") then
          found[#found + 1] = m[1]
        end
      end
    end
  end
  return found
end

-- 1. First open: attach starts converting (identify on a big png takes seconds).
vim.cmd.edit(png)
local buf = vim.api.nvim_get_current_buf()
Snacks.image.buf.attach(buf)
vim.wait(200)

-- 2. Close the buffer while the conversion is still running.
vim.cmd("bdelete!")
vim.wait(500)

-- 3. Reopen the same file (nvim reuses the same buffer for the same name).
vim.cmd.edit(png)
buf = vim.api.nvim_get_current_buf()

-- 4. Wait until the image is fully converted and ready, plus some slack.
local img
vim.wait(60000, function()
  local m = require("snacks.image.image")
  for i = 1, 30 do
    local n, v = debug.getupvalue(m.new, i)
    if n == "images" then
      img = v[vim.fs.normalize(vim.fn.fnamemodify(png, ":p"))]
      break
    end
  end
  return img ~= nil and img:ready()
end)
vim.wait(3000) -- plenty of 80ms timer ticks after the image became ready

print(("image ready: %s"):format(img and img:ready()))
print(("spinner extmarks still present: %d"):format(#spinner_extmarks(buf)))

if img and img:ready() and #spinner_extmarks(buf) > 0 then
  print("BUG REPRODUCED: image is ready but the loading spinner is still being drawn")
  os.exit(1)
else
  print("OK: no leaked spinner")
  os.exit(0)
end
```

</details>

Interactive equivalent: `nvim big.png`, then `:bd!` before the conversion finishes, then `:e big.png`. The spinner runs forever; the cache `.info` file on disk confirms the conversion completed.

Results on `main` (882c996):

```
image ready: true
spinner extmarks still present: 1
BUG REPRODUCED: image is ready but the loading spinner is still being drawn
```

With this PR:

```
image ready: true
spinner extmarks still present: 0
OK: no leaked spinner
```

## Bug 2: placements latch hidden and never come back

### Symptom

Open an image file (it renders fine), switch the window to another buffer, then switch back. The image buffer is blank: no image, no spinner, nothing. It stays blank for the rest of the session. This was masked by bug 1 in flows where a conversion was racing (users saw the stuck spinner instead of the blank buffer); with bug 1 fixed, this one becomes clearly visible.

### Root cause

When the image buffer leaves its window, the `auto_resize` autocmds trigger `Placement:update()`, which finds zero windows showing the buffer and calls `hide()`:

```lua
if #state.wins == 0 then
  self:hide()
  return
end
```

`hide()` sets `self.hidden = true`. The only caller of `show()` is `snacks.image.inline` (inline doc images); nothing ever calls it for buffer placements created by `Snacks.image.buf.attach()`. So when the user switches back to the buffer, `update()` runs with `self.hidden` still true, and `Placement:_render()` strips all virtual text and blanks all virtual lines:

```lua
if self.hidden then
  e.virt_text = nil
  ...
```

The placement's extmarks exist but render as empty lines, permanently. Verified in a live session: the stuck buffer had `img:ready() == true`, `sent == true`, one open placement with `hidden = true`, and 58 blanked virtual lines. Setting `hidden = false` and calling `update()` immediately restored the image.

### Fix

In `update()`, when the buffer is visible in a window again, un-hide the placement. Inline placements are excluded: `snacks.image.inline` manages their hide/show state explicitly.

### Reproduction

<details>
<summary><code>hidden_latch_repro.lua</code> (click to expand)</summary>

```lua
-- Run:  nvim --clean --headless -l hidden_latch_repro.lua <snacks.nvim path> <png path>

local snacks_path, png = arg[1], arg[2]
assert(snacks_path and png, "usage: nvim --clean --headless -l hidden_latch_repro.lua <snacks.nvim> <png>")

vim.opt.runtimepath:prepend(snacks_path)
require("snacks").setup({ image = { enabled = true } })

local terminal = require("snacks.image.terminal")
terminal._terminal = { terminal = "kitty", version = "0.0-repro" }
local env = terminal.env()
env.supported, env.placeholders, env.remote = true, true, false
terminal.write = function() end

local ns = require("snacks.image.placement").ns

-- an image row is a virt_line whose chunks contain the unicode placeholder
-- payload; a hidden row is rendered as a single empty-string chunk
local function visible_image_rows(buf)
  local rows = 0
  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, ns, 0, -1, { details = true })) do
    for _, line in ipairs(m[4].virt_lines or {}) do
      local text = ""
      for _, chunk in ipairs(line) do
        text = text .. chunk[1]
      end
      if #text > 10 then
        rows = rows + 1
      end
    end
  end
  return rows
end

-- 1. Open the image and wait until it is rendered.
vim.cmd.edit(png)
local img_buf = vim.api.nvim_get_current_buf()
Snacks.image.buf.attach(img_buf)
vim.wait(10000, function()
  return visible_image_rows(img_buf) > 0
end)
local before = visible_image_rows(img_buf)
print(("rendered rows after first open: %d"):format(before))
assert(before > 0, "image never rendered; cannot test the hidden latch")

-- 2. Switch the window to another buffer (image buffer stays loaded).
vim.cmd.enew()
vim.wait(1000) -- let the auto_resize autocmds + debounced update run (hide path)

-- 3. Switch back to the image buffer.
vim.cmd.buffer(img_buf)
local placement
vim.wait(2000, function()
  local m = require("snacks.image.image")
  for i = 1, 30 do
    local n, v = debug.getupvalue(m.new, i)
    if n == "images" then
      local img = v[vim.fs.normalize(vim.fn.fnamemodify(png, ":p"))]
      if img then
        local _, p = next(img.placements)
        placement = p
      end
    end
  end
  return placement and not placement.hidden
end)

print(("after switching back: hidden=%s windows=%d"):format(tostring(placement.hidden), #placement:wins()))

if placement.hidden then
  print("BUG REPRODUCED: placement is latched hidden although its buffer is visible again;")
  print("the next update() renders all its virtual lines blanked and the image never reappears")
  os.exit(1)
else
  print("OK: placement was un-hidden after its buffer became visible again")
  os.exit(0)
end
```

</details>

Interactive equivalent: `nvim image.png` (renders), `:e some_other_file`, `:b#`. The image buffer comes back blank.

Results on `main` (882c996):

```
rendered rows after first open: 21
after switching back: hidden=true windows=1
BUG REPRODUCED: placement is latched hidden although its buffer is visible again
```

With this PR:

```
rendered rows after first open: 21
after switching back: hidden=false windows=1
OK: placement was un-hidden after its buffer became visible again
```

Also verified interactively (real terminal, real graphics): open image, `:e README.md`, `:b#`, and the image re-renders.

## Environment

- snacks.nvim: `main` at 882c996cf28183f4d63640de0b4c02ec886d01f2
- Neovim: v0.12.4 (Release, LuaJIT 2.1)
- OS: macOS (Darwin 24.6.0, arm64)
- ImageMagick: 7.1.2-27 Q16-HDRI
- Originally observed in Ghostty; both bugs reproduce in `nvim --clean --headless` with terminal I/O stubbed, so they are unrelated to the terminal, multiplexer, or graphics protocol

## Notes

- No behavior change for the normal paths: the spinner still animates while a visible placement converts, and inline doc images keep their explicit hide/show management.
- The two commits are separable if you prefer to take them individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
