### PR TITLE
fix(input): remove history of set lines

### DIFF
--- a/lua/snacks/input.lua
+++ b/lua/snacks/input.lua
@@ -232,7 +232,10 @@ function M.input(opts, on_confirm)
   ctx = { opts = opts, win = win }
   vim.fn.prompt_setprompt(win.buf, "")
   if opts.default then
+    local initial_undolevels = vim.bo[win.buf].undolevels
+    vim.bo[win.buf].undolevels = -1
     vim.api.nvim_buf_set_lines(win.buf, 0, -1, false, { opts.default })
+    vim.bo[win.buf].undolevels = initial_undolevels
   end
 
   local function highlight()


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

After a snacks.input buffer is created, the first line is set to some text, though there is an undo history of this, so I'm creating a pr to ensure that there is no history.\
In case it's unclear why this can be useful, here is an example:
You want to rename a variable to make it more clear, so you use the rename feature of snacks; you then add to the variable a suffix, but realize that it would be better if you added a prefix instead. Therefore, you press u some times to reset it to the original variable name but you accidentally press u one too many times, thereby creating friction as you now need to press ctrl+r to return to the original variable name. With no history of the input box ever being set, this problem will not arise.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
N/A

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
When u is pressed nothing is undone, since there is no undo history past this point

<img width="1920" height="1076" alt="image" src="https://github.com/user-attachments/assets/b47d790b-b78b-4bd7-a055-df1aadfd01ea" />