### PR TITLE
fix(image): use vim.fs to normalize path

### DIFF
--- a/lua/snacks/image/init.lua
+++ b/lua/snacks/image/init.lua
@@ -104,7 +104,7 @@ local defaults = {
     spell = false,
     statuscolumn = "",
   },
-  cache = vim.fn.stdpath("cache") .. "/snacks/image",
+  cache = vim.fn.stdpath("cache") .. vim.fs.normalize("/snacks/image"),
   debug = {
     request = false,
     convert = false,
@@ -228,7 +228,7 @@ end
 function M.langs()
   local queries = vim.api.nvim_get_runtime_file("queries/*/images.scm", true)
   return vim.tbl_map(function(q)
-    return q:match("queries/(.-)/images%.scm")
+  return vim.fs.normalize(q):match("queries/(.-)/images%.scm")
   end, queries)
 end
 


### PR DESCRIPTION
I found that `Snacks.image.langs()` always returned empty table on Windows, which makes me unable to render LaTeX equations by `Snacks.image.hover()`. This is because '/' is hard encoded while Windows use '\\' as path separator:

<https://github.com/folke/snacks.nvim/blob/882c996cf28183f4d63640de0b4c02ec886d01f2/lua/snacks/image/init.lua#L229>

Yet another line:

<https://github.com/folke/snacks.nvim/blob/882c996cf28183f4d63640de0b4c02ec886d01f2/lua/snacks/image/init.lua#L107>