### PR TITLE
fix(lazygit): only write palette escapes when a TUI can receive them

### DIFF
--- a/lua/snacks/lazygit.lua
+++ b/lua/snacks/lazygit.lua
@@ -140,6 +140,24 @@ local function get_color(v)
   return color
 end
 
+--- Whether the builtin TUI is attached to a terminal that can receive escape
+--- sequences, checked at call time since UIs can attach and detach over a
+--- session. This is the same check Neovim core uses before emitting escape
+--- sequences (`runtime/lua/vim/_defaults.lua`). With a GUI frontend (Neovide,
+--- neovim-qt, any `--embed` client) stdout is the msgpack-RPC channel instead,
+--- so writing to it corrupts the protocol stream.
+local function tui_attached()
+  if vim.fn.has("nvim-0.10") == 0 then
+    return true -- `stdout_tty` is only reported on 0.10+, keep the old behavior
+  end
+  for _, ui in ipairs(vim.api.nvim_list_uis()) do
+    if ui.chan == 1 and ui.stdout_tty then
+      return true
+    end
+  end
+  return false
+end
+
 ---@param opts snacks.lazygit.Config
 local function update_config(opts)
   ---@type table<string, string[]>
@@ -150,7 +168,11 @@ local function update_config(opts)
       local color = get_color(v)
       -- LazyGit uses color 241 a lot, so also set it to a nice color
       -- pcall, since some terminals don't like this
-      pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1]))
+      if vim.api.nvim_ui_send then -- 0.12+: routed to the TUI host terminal, no-op for GUIs
+        pcall(vim.api.nvim_ui_send, ("\27]4;%d;%s\7"):format(k, color[1]))
+      elseif tui_attached() then
+        pcall(io.write, ("\27]4;%d;%s\7"):format(k, color[1]))
+      end
     else
       theme[k] = get_color(v)
     end


### PR DESCRIPTION
Fixes #2921

`Snacks.lazygit` writes OSC 4 palette escapes for numeric theme keys straight to stdout. With a GUI frontend (Neovide, neovim-qt, any `--embed` client) stdout is the msgpack-RPC channel, so the bytes corrupt the protocol stream instead of reaching a terminal; Neovide logs `ERROR [neovide::bridge::session] ]4;241;...` on every lazygit open.

This PR guards the write the same way Neovim core does:

- On 0.12+ it uses `vim.api.nvim_ui_send()`, which is routed to the TUI host terminal and is a no-op for GUIs; core's OSC 52 clipboard moved to it.
- On 0.10/0.11 it falls back to the `nvim_list_uis()` check from `runtime/lua/vim/_defaults.lua` (`ui.chan == 1 and ui.stdout_tty`). Under Neovide the attached UI reports `chan == 1, stdout_tty == false`, so `stdout_tty` is the discriminating field.
- On 0.9 the `stdout_tty` field does not exist yet, so the old behavior is kept there.

Same fix as AstroNvim/astroui#66, where this code was adapted to.

Tested on Neovim 0.12.4 with the repro from #2921: headless/GUI path no longer leaks the escape; under a real pty the escape still reaches the terminal. `stylua --check` and `selene` are clean on the changed file.
