### PR TITLE
feat(picker.preview): add option to opt out of real-buffer preview

### DIFF
--- a/lua/snacks/picker/config/defaults.lua
+++ b/lua/snacks/picker/config/defaults.lua
@@ -198,6 +198,7 @@ local defaults = {
       max_size = 1024 * 1024, -- 1MB
       max_line_length = 500, -- max line length
       ft = nil, ---@type string? filetype for highlighting. Use `nil` for auto detect
+      use_real_buffer = true ---@type boolean use actual buffer as preview when the file is already loaded (default: true)
     },
     man_pager = nil, ---@type string? MANPAGER env to use for `man` preview
   },

--- a/lua/snacks/picker/preview.lua
+++ b/lua/snacks/picker/preview.lua
@@ -101,7 +101,7 @@ function M.file(ctx)
     vim.fn.bufload(ctx.item.buf)
   end
 
-  if ctx.item.buf and vim.api.nvim_buf_is_loaded(ctx.item.buf) then
+  if ctx.item.buf and vim.api.nvim_buf_is_loaded(ctx.item.buf) and ctx.picker.opts.previewers.file.use_real_buffer then
     if not title then
       local name = vim.api.nvim_buf_get_name(ctx.item.buf)
       title = uv.fs_stat(name) and vim.fn.fnamemodify(name, ":t") or name


### PR DESCRIPTION
## Description

Picker previews can be of two types: scratch buffers or real buffers. Scratch buffers are used when the file isn't already open, while real buffers are used when the file is already loaded.

Using a real buffer means the preview inherits the buffer's existing state and keymaps, which can interfere with picker-specific keymaps (see https://github.com/folke/snacks.nvim/issues/1417). It also updates the buffer's last-used timestamp, which can affect picker sorting (see https://github.com/folke/snacks.nvim/issues/773).

For my use cases, having the real-buffer preview has no benefits. Other users also seem to feel the same way (https://github.com/folke/snacks.nvim/issues/773#issuecomment-4467371981).

This PR adds a `use_real_buffer` option to allow users to opt out of real-buffer previews and always use scratch buffers instead. You would opt out by setting `picker.previewers.file.use_real_buffer = false`.

## Related Issue(s)

https://github.com/folke/snacks.nvim/issues/1417
https://github.com/folke/snacks.nvim/issues/773
