### PR TITLE
fix(picker.lspconfig): take into account when cmd is a function

### DIFF
--- a/lua/snacks/picker/source/lsp/config.lua
+++ b/lua/snacks/picker/source/lsp/config.lua
@@ -138,6 +138,17 @@ function M.find(opts, ctx)
           installed = bins[cmd[1]] ~= nil
         end
         cmd[1] = vim.fs.basename(cmd[1])
+      elseif type(cmd) == "function" and item.enabled then
+        local ok, result = pcall(cmd)
+        ---@type any
+        local any = result
+        if ok and any and any.transport and any.transport.cmd and type(any.transport.cmd) == "table" then
+          if bins[any.transport.cmd[1]] then
+            cmd = any.transport.cmd
+            bin = bins[any.transport.cmd[1]]
+            installed = true
+          end
+        end
       end
       local want = (not opts.installed or installed) and (not opts.configured or item.enabled)
       if opts.attached == true and not item.attached then


### PR DESCRIPTION
## Description
Takes into account when cmd is a function. Not sure about the approach of using Neovim private fields, but couldn't find another solution. The alternative would be to add a guard in `M.preview()` when `type(cmd) == "function"` and show message that the installed binary could not be determined instead of showing `not installed`.

I also opted to only do this for items that have `item.enabled`, otherwise the `pcall` would execute for all available items and in some cases I would get `Could not connect to 127.0.0.1:6005, reason: "ECONNREFUSED"`, which I assume is because the `pcall` is executed for LSP servers that are not available on the system.
<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
Fixes #2932
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

