### PR TITLE
fix(indent): underline highlight at correct column when tabs indent

### DIFF
--- a/lua/snacks/indent.lua
+++ b/lua/snacks/indent.lua
@@ -316,7 +316,8 @@ function M.render_scope(scope, state)
   if config.scope.underline and scope.from == from then
     local scope_first_line = vim.api.nvim_buf_get_lines(scope.buf, scope.from - 1, scope.from, false)[1]
     if scope_first_line ~= nil then
-      vim.api.nvim_buf_set_extmark(scope.buf, ns, scope.from - 1, math.max(col, 0), {
+      local col_eval = (vim.bo[scope.buf].expandtab and col or math.floor(col / state.shiftwidth))
+      vim.api.nvim_buf_set_extmark(scope.buf, ns, scope.from - 1, math.max(col_eval, 0), {
         end_col = #scope_first_line,
         hl_group = get_underline_hl(hl),
         hl_mode = "combine",


### PR DESCRIPTION
## Description

- indent plugin can't correctly underline first line of indent if user indents with tabs instead of spaces
- reason
    - user setting not checked and beginning of highlight moved by shiftwidth
    - e.g.: if shiftwidth is 4 then one indent highlight begins at col 3, two indents highlight begins  at col 6 etc.
- solution
    - check if user has vim.bo.expandtab set
    - if true divide and round down start column by shiftwidth

## Related Issue(s)

https://github.com/folke/snacks.nvim/issues/404


