### PR TITLE
fix(explorer): handle Windows drive roots correctly in tree

### DIFF
--- a/lua/snacks/explorer/tree.lua
+++ b/lua/snacks/explorer/tree.lua
@@ -26,7 +26,13 @@
 local uv = vim.uv or vim.loop
 
 local function norm(path)
-  return svim.fs.normalize(path):gsub("/$", ""):gsub("^$", "/")
+  path = svim.fs.normalize(path)
+  -- keep trailing slash for Windows drive roots (D:/), otherwise
+  -- scandir("D:") resolves to the drive's current dir, not its root
+  if not path:match("^%a:/$") then
+    path = path:gsub("/$", "")
+  end
+  return path:gsub("^$", "/")
 end
 
 local function assert_dir(path)
@@ -77,9 +83,18 @@ end
 ---@param name string
 ---@param type string
 function Tree:child(node, name, type)
+  -- skip empty segment from trailing slash (e.g. drive root "D:/")
+  if name == "" then
+    return node
+  end
   if not node.children[name] then
-    local path = node.path .. "/" .. name
-    path = node == self.root and name or path
+    -- strip trailing slash from parent so drive roots don't double up ("D://name")
+    local base = node.path:gsub("/$", "")
+    local path = base .. "/" .. name
+    -- drive-letter root ("D:") keeps its trailing slash, so scandir hits the root
+    if node == self.root then
+      path = name:match("^%a:$") and (name .. "/") or name
+    end
     node.children[name] = {
       name = name,
       path = path,


### PR DESCRIPTION
## Problem

On Windows, `scandir("D:")` (no trailing slash) resolves to the drive's **current directory** (e.g. `D:/ob1`) instead of the drive **root** `D:/`.

snacks' explorer `tree.norm()` stripped the trailing slash from `"D:/"` producing `"D:"`. So opening or navigating to a drive root showed the current directory's contents (stale/obfuscated) instead of the actual root.

Repro: open explorer at `D:/ob1`, press `<BS>` (explorer_up) → it goes to `D:/` but the list still shows `ob1`'s children (Inbox, Life, ...) mislabeled as `D:/...` instead of the real root (79+ entries on the user's drive).

## Fix

In `lua/snacks/explorer/tree.lua`:

1. **`norm`**: keep the trailing slash for Windows drive roots (`D:/`), so `scandir("D:/")` resolves to the actual root.
2. **`Tree:child`**: skip empty path segments produced by the trailing slash, and keep the trailing slash for drive-letter root nodes (`D:/`), while avoiding double slashes (`D://name`) when concatenating child paths.

## Verified

Headless on Windows (nvim + real snacks):
- `open D:/` now shows the real drive root contents (many entries), not the stale current-dir list
- opening `D:/ob1` / `D:/ob1/nvim` unchanged
- navigating from `D:/ob1` up to `D:/` now lists the drive root correctly
- no double slashes in item paths