### PR TITLE
fix(picker.actions): clamp cursor line when the buffer shrank

### DIFF
--- a/lua/snacks/picker/actions.lua
+++ b/lua/snacks/picker/actions.lua
@@ -146,7 +146,8 @@ function M.jump(picker, _, action)
     pos = picker.matcher:bufpos(vim.api.nvim_get_current_buf(), item) or pos
   end
   if pos and pos[1] > 0 then
-    vim.api.nvim_win_set_cursor(win, { pos[1], pos[2] })
+    local last_line = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(win))
+    vim.api.nvim_win_set_cursor(win, { math.min(pos[1], last_line), pos[2] })
     vim.cmd("norm! zzzv")
   elseif item.search then
     vim.cmd(item.search)


### PR DESCRIPTION
## Description

`M.jump` restores the cursor from `item.pos`, which the finder snapshotted when the picker opened:

```lua
vim.api.nvim_win_set_cursor(win, { pos[1], pos[2] })
```

If the buffer has fewer lines by the time the pick is confirmed, this raises `Invalid cursor line: out of range`.

Terminal buffers hit it regularly. A terminal buffer has one line per row of the window showing it, and previewing a loaded buffer puts the real buffer in the preview window (`picker/preview.lua:110`), which resizes the pty down to the preview's height. The position was captured before that, so on confirm `M.jump` asks for a line the shrunken buffer no longer has.

This clamps the line to the buffer's last line. The column already gets clamped by `nvim_win_set_cursor`.

Tested with the repro from #2939, and by driving the buffers picker over a buffer that shrinks while the picker is open: before, `actions.lua:149: Invalid cursor line: out of range`; after, the jump lands on the last line. `./scripts/test` passes.

One thing I did not do, since it is a behaviour choice: for `buftype == "terminal"` it may be better to skip the cursor restore altogether, because the clamped line stops meaning anything as soon as the pty resizes back. Happy to change it to that.

## Related Issue(s)

- Fixes #2939
