### PR TITLE
fix(image): process png images through magick if available

### DIFF
--- a/lua/snacks/image/convert.lua
+++ b/lua/snacks/image/convert.lua
@@ -202,6 +202,13 @@ local proc_queue = {} ---@type snacks.spawn.Proc[]
 local proc_running = 0 ---@type number
 local MAX_PROCS = 3
 
+local function has_magick()
+  if have.magick == nil then
+    have.magick = vim.fn.executable("magick") == 1 or (not Snacks.util.is_win and vim.fn.executable("convert") == 1)
+  end
+  return have.magick
+end
+
 ---@param proc? snacks.spawn.Proc
 local function schedule(proc)
   if proc then
@@ -329,7 +336,7 @@ function Convert:resolve()
     self:_resolve("url")
     self:_resolve("identify")
   end
-  while self:ft() ~= "png" do
+  while self:ft() ~= "png" or (#self.steps == 0 and has_magick()) do
     local ft = self:ft()
     local target = commands[ft] and ft or "convert"
     if self:_resolve(target) then


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

Ensure that image files are downscaled with ImageMagick when magick is available, even if the file extension is already png. Rendering a full high res PNG screenshot without downscaling would often get to over 50MB for the raw RGBA data. This may cause lag on the terminal emulator. This new behavior is also less surprising by enforcing the "default" convert command on png, which is documented as "default for raster images".

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->
