### PR TITLE
fix(gitbrowse): dont prepend a second scheme to plain http remotes

### DIFF
--- a/lua/snacks/gitbrowse.lua
+++ b/lua/snacks/gitbrowse.lua
@@ -93,7 +93,7 @@ function M.get_repo(remote, opts)
   for _, pattern in ipairs(opts.remote_patterns) do
     ret = ret:gsub(pattern[1], pattern[2]) --[[@as string]]
   end
-  return ret:find("https://") == 1 and ret or ("https://%s"):format(ret)
+  return ret:find("https?://") == 1 and ret or ("https://%s"):format(ret)
 end
 
 ---@param repo string

--- a/tests/gitbrowse_spec.lua
+++ b/tests/gitbrowse_spec.lua
@@ -30,6 +30,8 @@ local git_remotes_cases = {
   ["https://git.sr.ht/~user/repo"]                                       = "https://git.sr.ht/~user/repo",
   ["git@git.sr.ht:~user/another-repo"]                                   = "https://git.sr.ht/~user/another-repo",
   ["https://git.sr.ht/~user/another-repo"]                               = "https://git.sr.ht/~user/another-repo",
+  ["http://git.example.com/group/subgroup/repo.git"]                     = "http://git.example.com/group/subgroup/repo",
+  ["http://git.example.com/group/subgroup/repo"]                         = "http://git.example.com/group/subgroup/repo",
 }
 
 describe("util.lazygit", function()


### PR DESCRIPTION
## Description

A simple fix for the bug reported in #2954 (also a couple of test cases validating the intended behavior).

The problem happens when a remote is served over plain `http://` (e.g.: self-hosted GitLab behind a corporate network). When that happens gitbrowse prepends a second scheme to the URL:

```
remote: http://git.example.com/group/subgroup/repo.git
result: https://http://git.example.com/group/subgroup/repo
```

## Related Issue(s)

closes #2954 